### PR TITLE
Switch to Duration from `time` crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ exclude = ['.gitignore', '.cargo/config', '.vscode', '.devcontainer', '.github']
 [workspace.dependencies]
 anyhow = "1.0"
 arrow = { version = "52", default-features = false }
+time = { version = "0.3", features = [] }
 document-features = "0.2"
 erased-serde = "0.4"
 itertools = "0.13"

--- a/boomerang/benches/physical_actions.rs
+++ b/boomerang/benches/physical_actions.rs
@@ -101,7 +101,7 @@ fn bench(c: &mut Criterion) {
             |(env, triggers)| {
                 let config = runtime::Config::default()
                     .with_fast_forward(false)
-                    .with_timeout(Duration::from_secs(1));
+                    .with_timeout(Duration::seconds(1));
                 let mut sched = runtime::Scheduler::new(env, triggers, config);
                 sched.event_loop();
             },

--- a/boomerang/src/lib.rs
+++ b/boomerang/src/lib.rs
@@ -82,7 +82,7 @@ pub mod prelude {
         TimerActionKey, TypedActionKey, TypedPortKey,
     };
 
-    pub use super::runtime::{self, ContextCommon, FromRefs};
+    pub use super::runtime::{self, ContextCommon, Duration, FromRefs};
 
     pub use boomerang_derive::{Reaction, Reactor};
 }

--- a/boomerang/tests/action_delay.rs
+++ b/boomerang/tests/action_delay.rs
@@ -1,7 +1,5 @@
 //! Test logical action with delay.
 
-use std::time::Duration;
-
 use boomerang::prelude::*;
 
 #[derive(Default, Debug)]
@@ -90,7 +88,7 @@ impl runtime::Trigger<bool> for SinkReactionIn<'_> {
         println!("physical time: {:?}", physical);
         println!("elapsed logical time: {:?}", elapsed_logical);
         assert!(
-            elapsed_logical == Duration::from_millis(100),
+            elapsed_logical == Duration::milliseconds(100),
             "ERROR: Expected 100 msecs but got {:?}",
             elapsed_logical
         );

--- a/boomerang/tests/action_is_present.rs
+++ b/boomerang/tests/action_is_present.rs
@@ -1,7 +1,5 @@
 //! Tests is_present
 
-use std::time::Duration;
-
 use boomerang::prelude::*;
 
 #[derive(Default)]
@@ -32,7 +30,7 @@ impl runtime::Trigger<ActionIsPresentState> for ReactionStartup<'_> {
         if !self.a.is_present(ctx) {
             assert!(!state.success, "Unexpected");
             println!("Hello startup!");
-            self.a.schedule(ctx, (), Some(Duration::from_nanos(1)));
+            self.a.schedule(ctx, (), Some(Duration::nanoseconds(1)));
         } else {
             println!("Hello a!");
             state.success = true;

--- a/boomerang/tests/action_values.rs
+++ b/boomerang/tests/action_values.rs
@@ -1,7 +1,5 @@
 //! Test logical action with delay.
 
-use std::time::Duration;
-
 use boomerang::prelude::*;
 
 #[derive(Default, Debug)]
@@ -35,7 +33,7 @@ impl<'a> runtime::Trigger<State> for ReactionStartup<'a> {
         self.act.schedule(ctx, 100, None);
         // scheduled in 150 ms, value is overwritten
         self.act
-            .schedule(ctx, -100, Some(Duration::from_millis(50)));
+            .schedule(ctx, -100, Some(Duration::milliseconds(50)));
     }
 }
 
@@ -53,11 +51,11 @@ impl<'a> runtime::Trigger<State> for ReactionAct<'a> {
 
         println!("[@{elapsed:?} action transmitted: {value:?}]");
 
-        if elapsed.as_millis() == 100 {
+        if elapsed.whole_milliseconds() == 100 {
             assert_eq!(value, Some(&100), "ERROR: Expected action value to be 100");
             state.r1done = true;
         } else {
-            if elapsed.as_millis() != 150 {
+            if elapsed.whole_milliseconds() != 150 {
                 panic!("ERROR: Unexpected reaction invocation at {elapsed:?}");
             }
             assert_eq!(

--- a/boomerang/tests/after.rs
+++ b/boomerang/tests/after.rs
@@ -1,7 +1,5 @@
 //! This checks that the after keyword adjusts logical time, not using physical time.
 
-use std::time::Duration;
-
 use boomerang::prelude::*;
 
 #[derive(Reactor)]
@@ -33,7 +31,7 @@ struct PrintState {
 impl Default for PrintState {
     fn default() -> Self {
         Self {
-            expected_time: Duration::from_millis(10),
+            expected_time: Duration::milliseconds(10),
             i: 0,
         }
     }
@@ -68,7 +66,7 @@ impl runtime::Trigger<PrintState> for ReactionPrintX<'_> {
             "Expected logical time to be {:?}",
             state.expected_time
         );
-        state.expected_time += Duration::from_secs(1);
+        state.expected_time += Duration::seconds(1);
     }
 }
 
@@ -120,6 +118,6 @@ fn after() {
     tracing_subscriber::fmt::init();
     let config = runtime::Config::default()
         .with_fast_forward(true)
-        .with_timeout(Duration::from_secs(3));
+        .with_timeout(Duration::seconds(3));
     let _ = boomerang_util::runner::build_and_test_reactor::<Main>("after", (), config).unwrap();
 }

--- a/boomerang/tests/async_callback.rs
+++ b/boomerang/tests/async_callback.rs
@@ -1,7 +1,7 @@
 //! Test asynchronous callbacks that trigger a physical action.
 
 use boomerang::prelude::*;
-use std::{thread::JoinHandle, time::Duration};
+use std::thread::JoinHandle;
 
 #[derive(Debug, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -45,7 +45,7 @@ impl runtime::Trigger<State> for ReactionT {
         // start new thread
         state.thread = Some(std::thread::spawn(move || {
             // Simulate time passing before a callback occurs
-            std::thread::sleep(Duration::from_millis(100));
+            std::thread::sleep(std::time::Duration::from_millis(100));
             // Schedule twice. If the action is not physical, these should get consolidated into a single action
             // triggering. If it is, then they cause two separate triggerings with close but not equal time stamps.
             a.schedule(&send_ctx, 0, None);
@@ -74,7 +74,7 @@ impl runtime::Trigger<State> for ReactionA {
         }
         if state.toggle {
             state.toggle = false;
-            state.expected_time += Duration::from_millis(200);
+            state.expected_time += Duration::milliseconds(200);
         } else {
             state.toggle = true;
         }
@@ -99,12 +99,12 @@ fn async_callback() {
     tracing_subscriber::fmt::init();
     let config = runtime::Config::default()
         .with_fast_forward(false)
-        .with_timeout(Duration::from_secs(2));
+        .with_timeout(Duration::seconds(2));
     let _ = boomerang_util::runner::build_and_test_reactor::<AsyncCallback>(
         "async_callback",
         State {
             thread: None,
-            expected_time: Duration::from_millis(100),
+            expected_time: Duration::milliseconds(100),
             toggle: false,
             i: 0,
         },

--- a/boomerang/tests/count.rs
+++ b/boomerang/tests/count.rs
@@ -1,6 +1,6 @@
 use boomerang::prelude::*;
 
-use std::{fmt::Debug, time::Duration};
+use std::fmt::Debug;
 
 trait CountData:
     Debug + Copy + runtime::ReactorData + std::ops::AddAssign<i32> + std::cmp::PartialEq<i32>
@@ -48,7 +48,7 @@ fn count() {
     tracing_subscriber::fmt::init();
     let config = runtime::Config::default()
         .with_fast_forward(true)
-        .with_timeout(Duration::from_secs(1));
+        .with_timeout(Duration::seconds(1));
     let (_, sched) =
         boomerang_util::runner::build_and_test_reactor::<Count<i32>>("count", 0, config).unwrap();
     let env = sched.into_env();

--- a/boomerang/tests/hello.rs
+++ b/boomerang/tests/hello.rs
@@ -2,8 +2,6 @@
 //! schedule_action() function at runtime. It also performs various smoke tests of timing aligned reactions. The first
 //! instance has a period of 4 seconds, the second of 2 seconds, and the third (composite) or 1 second.
 
-use std::time::Duration;
-
 use boomerang::prelude::*;
 
 #[derive(Debug, Default)]
@@ -46,7 +44,7 @@ impl runtime::Trigger<Hello> for ReactionT<'_> {
     fn trigger(mut self, ctx: &mut runtime::Context, state: &mut Hello) {
         // Print the current time.
         state.previous_time = ctx.get_elapsed_logical_time();
-        self.a.schedule(ctx, (), Some(Duration::from_millis(200))); // No payload.
+        self.a.schedule(ctx, (), Some(Duration::milliseconds(200))); // No payload.
         println!(
             "{} Current time is {:?}",
             state.message, state.previous_time
@@ -67,7 +65,7 @@ impl runtime::Trigger<Hello> for ReactionA {
         let diff = time - state.previous_time;
         assert_eq!(
             diff,
-            Duration::from_millis(200),
+            Duration::milliseconds(200),
             "FAILURE: Expected 200 msecs of logical time to elapse but got {:?}",
             diff
         );
@@ -91,16 +89,16 @@ impl Inside {
 #[derive(Reactor)]
 #[reactor(state = Inside)]
 struct InsideBuilder {
-    #[reactor(child = Hello::new(Duration::from_secs(1), "Composite default message."))]
+    #[reactor(child = Hello::new(Duration::seconds(1), "Composite default message."))]
     _third_instance: HelloBuilder,
 }
 
 #[derive(Reactor)]
 #[reactor(state = ())]
 struct MainBuilder {
-    #[reactor(child = Hello::new(Duration::from_secs(4), "Hello from first."))]
+    #[reactor(child = Hello::new(Duration::seconds(4), "Hello from first."))]
     _first_instance: HelloBuilder,
-    #[reactor(child = Hello::new(Duration::from_secs(2), "Hello from second."))]
+    #[reactor(child = Hello::new(Duration::seconds(2), "Hello from second."))]
     _second_instance: HelloBuilder,
     #[reactor(child = Inside::new("Hello from composite."))]
     _third_instance: InsideBuilder,
@@ -111,7 +109,7 @@ fn hello() {
     tracing_subscriber::fmt::init();
     let config = runtime::Config::default()
         .with_fast_forward(true)
-        .with_timeout(Duration::from_secs(10));
+        .with_timeout(Duration::seconds(10));
     let _ =
         boomerang_util::runner::build_and_test_reactor::<MainBuilder>("hello", (), config).unwrap();
 }

--- a/boomerang/tests/physical_action_with_keepalive.rs
+++ b/boomerang/tests/physical_action_with_keepalive.rs
@@ -1,5 +1,4 @@
 use boomerang::prelude::*;
-use std::time::Duration;
 
 #[derive(Reactor)]
 #[reactor(state = "bool", reaction = "ReactionStartup", reaction = "ReactionAct")]
@@ -18,7 +17,7 @@ impl runtime::Trigger<bool> for ReactionStartup {
         let send_ctx = ctx.make_send_context();
         let act = self.act.clone();
         std::thread::spawn(move || {
-            std::thread::sleep(Duration::from_millis(20));
+            std::thread::sleep(std::time::Duration::from_millis(20));
             act.schedule(&send_ctx, 434, None);
         });
     }
@@ -37,7 +36,7 @@ impl runtime::Trigger<bool> for ReactionAct<'_> {
         println!("---- Vu {} à {}", value, ctx.get_tag());
 
         let elapsed_time = ctx.get_elapsed_logical_time();
-        assert!(elapsed_time >= Duration::from_millis(20));
+        assert!(elapsed_time >= Duration::milliseconds(20));
         println!("success");
         *_state = true;
         ctx.schedule_shutdown(None);

--- a/boomerang/tests/slowing_clock_physical.rs
+++ b/boomerang/tests/slowing_clock_physical.rs
@@ -4,8 +4,6 @@
 //! drifting away further with each new event. Modeled after the Lingua-Franca C version of this
 //! test. @author Maiko Brants TU Dresden
 
-use std::time::Duration;
-
 use boomerang::prelude::*;
 
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -35,7 +33,7 @@ struct ReactionStartup<'a> {
 
 impl runtime::Trigger<State> for ReactionStartup<'_> {
     fn trigger(mut self, ctx: &mut runtime::Context, state: &mut State) {
-        state.expected_time = Duration::from_millis(100);
+        state.expected_time = Duration::milliseconds(100);
         self.a.schedule(ctx, (), None);
     }
 }
@@ -56,8 +54,8 @@ impl runtime::Trigger<State> for ReactionA<'_> {
             "Expected logical time to be at least: {:?}, was {elapsed_logical_time:?}",
             state.expected_time
         );
-        state.interval += Duration::from_millis(100);
-        state.expected_time = Duration::from_millis(100) + state.interval;
+        state.interval += Duration::milliseconds(100);
+        state.expected_time = Duration::milliseconds(100) + state.interval;
         println!(
             "Scheduling next to occur approximately after: {:?}",
             state.interval
@@ -73,7 +71,7 @@ struct ReactionShutdown;
 impl runtime::Trigger<State> for ReactionShutdown {
     fn trigger(self, _ctx: &mut runtime::Context, state: &mut State) {
         assert!(
-            state.expected_time >= Duration::from_millis(500),
+            state.expected_time >= Duration::milliseconds(500),
             "Expected the next expected time to be at least: 500000000 nsec. It was: {:?}",
             state.expected_time
         );
@@ -86,12 +84,12 @@ fn slowing_clock_physical() {
     let config = runtime::Config::default()
         .with_fast_forward(true)
         .with_keep_alive(true)
-        .with_timeout(Duration::from_millis(1500));
+        .with_timeout(Duration::milliseconds(1500));
     let _ = boomerang_util::runner::build_and_test_reactor::<SlowingClockPhysical>(
         "slowing_clock_physical",
         State {
-            interval: Duration::from_millis(100),
-            expected_time: Duration::from_millis(200),
+            interval: Duration::milliseconds(100),
+            expected_time: Duration::milliseconds(200),
         },
         config,
     )

--- a/boomerang/tests/threading_multiport.rs
+++ b/boomerang/tests/threading_multiport.rs
@@ -3,7 +3,6 @@
 //! Ported from LF https://github.com/lf-lang/lingua-franca/blob/master/test/C/src/concurrent/ThreadedMultiport.lf
 
 use boomerang::prelude::*;
-use std::time::Duration;
 
 #[derive(Debug)]
 pub struct State {
@@ -59,7 +58,7 @@ mod computation {
             let mut offset = 0;
             for _ in 0..*state {
                 offset += 1;
-                //std::thread::sleep(std::time::Duration::from_nanos(1));
+                //std::thread::sleep(std::time::Duration::nanosecondss(1));
             }
             *self.out = self.in_.map(|x| x + offset);
         }
@@ -134,7 +133,7 @@ fn threading_multiport() {
     tracing_subscriber::fmt::init();
     let config = runtime::Config::default()
         .with_fast_forward(true)
-        .with_timeout(Duration::from_secs(2));
+        .with_timeout(Duration::seconds(2));
     let _ = boomerang_util::runner::build_and_test_reactor::<ThreadedMultiport<4, 10_000>>(
         "threaded_multiport",
         (),

--- a/boomerang_builder/src/action.rs
+++ b/boomerang_builder/src/action.rs
@@ -4,7 +4,7 @@
 //! An action, like a port (see [`crate::builder::PortBuilder`]), can carry data, but unlike a port,
 //! an action is visible only within the reactor that defines it.
 
-use std::{fmt::Debug, marker::PhantomData, time::Duration};
+use std::{fmt::Debug, marker::PhantomData};
 
 use super::{BuilderReactionKey, BuilderReactorKey};
 use crate::{runtime, ParentReactorBuilder};
@@ -114,9 +114,9 @@ impl From<BuilderActionKey> for TimerActionKey {
 #[derive(Debug, PartialEq, Eq)]
 pub struct TimerSpec {
     /// Interval between timer events
-    pub period: Option<Duration>,
+    pub period: Option<runtime::Duration>,
     /// (logical) time interval between when the program starts executing and the first timer event
-    pub offset: Option<Duration>,
+    pub offset: Option<runtime::Duration>,
 }
 
 #[derive(Debug)]
@@ -128,7 +128,7 @@ pub enum ActionType {
         /// Whether the action is logical or physical
         is_logical: bool,
         /// Minimum delay between
-        min_delay: Option<Duration>,
+        min_delay: Option<runtime::Duration>,
         /// Builder function that creates the runtime action
         build_fn: Box<dyn ActionBuilderFn>,
     },

--- a/boomerang_builder/src/connection.rs
+++ b/boomerang_builder/src/connection.rs
@@ -1,5 +1,3 @@
-use std::time::Duration;
-
 use crate::{
     runtime, ActionTag, BuilderError, BuilderReactorKey, EnvBuilder, Input, Output, Reaction,
     ReactionBuilderState, ReactionField, ReactorBuilderState, ReactorField, TriggerMode,
@@ -14,7 +12,7 @@ pub struct ConnectionBuilder<T: runtime::ReactorData, Q: ActionTag> {
 
 /// We use the `state` to pass the delay duration for the connection.
 impl<T: runtime::ReactorData + Clone, Q: ActionTag> crate::Reactor for ConnectionBuilder<T, Q> {
-    type State = Duration;
+    type State = runtime::Duration;
 
     fn build(
         name: &str,

--- a/boomerang_builder/src/env/mod.rs
+++ b/boomerang_builder/src/env/mod.rs
@@ -12,7 +12,6 @@ use slotmap::{SecondaryMap, SlotMap};
 use std::{
     collections::{BTreeSet, HashMap},
     convert::TryInto,
-    time::Duration,
 };
 
 mod build;
@@ -167,7 +166,7 @@ impl EnvBuilder {
     pub fn internal_add_action<T: runtime::ReactorData, Q: ActionTag>(
         &mut self,
         name: &str,
-        min_delay: Option<Duration>,
+        min_delay: Option<runtime::Duration>,
         reactor_key: BuilderReactorKey,
     ) -> Result<TypedActionKey<T, Q>, BuilderError> {
         self.add_action::<T, Q>(
@@ -371,7 +370,7 @@ impl EnvBuilder {
         &mut self,
         source_key: P1,
         target_key: P2,
-        after: Option<Duration>,
+        after: Option<runtime::Duration>,
         physical: bool,
     ) -> Result<(), BuilderError>
     where

--- a/boomerang_builder/src/env/tests.rs
+++ b/boomerang_builder/src/env/tests.rs
@@ -50,8 +50,8 @@ fn test_duplicate_actions() {
             .add_timer(
                 "action0",
                 TimerSpec {
-                    period: Some(Duration::ZERO),
-                    offset: Some(Duration::ZERO),
+                    period: Some(runtime::Duration::ZERO),
+                    offset: Some(runtime::Duration::ZERO),
                 }
             )
             .expect_err("Expected duplicate"),
@@ -115,7 +115,7 @@ fn test_actions1() {
     let mut reactor_builder = env_builder.add_reactor("test_reactor", None, None, ());
 
     let action_a = reactor_builder
-        .add_logical_action::<()>("a", Some(Duration::from_secs(1)))
+        .add_logical_action::<()>("a", Some(runtime::Duration::seconds(1)))
         .unwrap();
     let action_b = reactor_builder.add_logical_action::<()>("b", None).unwrap();
 

--- a/boomerang_builder/src/graphviz.rs
+++ b/boomerang_builder/src/graphviz.rs
@@ -90,9 +90,9 @@ fn build_actions(env_builder: &EnvBuilder, reactor: &ReactorBuilder, output: &mu
                     "⏲ (startup)".into()
                 } else {
                     format!(
-                        "⏲ ({} ms, {} ms)",
-                        offset.unwrap_or_default().as_millis(),
-                        period.unwrap_or_default().as_millis()
+                        "⏲ ({}, {})",
+                        offset.unwrap_or_default(),
+                        period.unwrap_or_default()
                     )
                 }
             }
@@ -102,9 +102,9 @@ fn build_actions(env_builder: &EnvBuilder, reactor: &ReactorBuilder, output: &mu
                 ..
             } => {
                 if *is_logical {
-                    format!("L({} ms)", min_delay.unwrap_or_default().as_millis())
+                    format!("L({})", min_delay.unwrap_or_default())
                 } else {
-                    format!("P({} ms)", min_delay.unwrap_or_default().as_millis())
+                    format!("P({} ms)", min_delay.unwrap_or_default())
                 }
             }
             ActionType::Startup => "Startup".into(),

--- a/boomerang_builder/src/reactor.rs
+++ b/boomerang_builder/src/reactor.rs
@@ -1,4 +1,4 @@
-use std::{fmt::Debug, time::Duration};
+use std::fmt::Debug;
 
 use super::{
     ActionType, BuilderActionKey, BuilderError, BuilderFqn, BuilderPortKey, BuilderReactionKey,
@@ -6,7 +6,6 @@ use super::{
     ReactionBuilderState, TimerActionKey, TimerSpec, TriggerMode, TypedActionKey, TypedPortKey,
 };
 use crate::{runtime, ActionTag, Input};
-use boomerang_runtime::BoxedReactionFn;
 use slotmap::SecondaryMap;
 
 slotmap::new_key_type! {
@@ -117,7 +116,7 @@ impl ReactorField for TimerActionKey {
 }
 
 impl<T: runtime::ReactorData, Q: ActionTag> ReactorField for TypedActionKey<T, Q> {
-    type Inner = Option<Duration>;
+    type Inner = Option<runtime::Duration>;
 
     fn build(
         name: &str,
@@ -129,7 +128,7 @@ impl<T: runtime::ReactorData, Q: ActionTag> ReactorField for TypedActionKey<T, Q
 }
 
 impl ReactorField for PhysicalActionKey {
-    type Inner = Option<Duration>;
+    type Inner = Option<runtime::Duration>;
 
     fn build(
         name: &str,
@@ -354,7 +353,7 @@ impl<'a> ReactorBuilderState<'a> {
     pub fn add_action<T: runtime::ReactorData, Q: ActionTag>(
         &mut self,
         name: &str,
-        min_delay: Option<Duration>,
+        min_delay: Option<runtime::Duration>,
     ) -> Result<TypedActionKey<T, Q>, BuilderError> {
         self.env
             .internal_add_action::<T, Q>(name, min_delay, self.reactor_key)
@@ -367,7 +366,7 @@ impl<'a> ReactorBuilderState<'a> {
     pub fn add_logical_action<T: runtime::ReactorData>(
         &mut self,
         name: &str,
-        min_delay: Option<Duration>,
+        min_delay: Option<runtime::Duration>,
     ) -> Result<TypedActionKey<T, Logical>, BuilderError> {
         self.env
             .internal_add_action::<T, Logical>(name, min_delay, self.reactor_key)
@@ -376,7 +375,7 @@ impl<'a> ReactorBuilderState<'a> {
     pub fn add_physical_action<T: runtime::ReactorData>(
         &mut self,
         name: &str,
-        min_delay: Option<Duration>,
+        min_delay: Option<runtime::Duration>,
     ) -> Result<TypedActionKey<T, Physical>, BuilderError> {
         self.env
             .internal_add_action::<T, Physical>(name, min_delay, self.reactor_key)
@@ -386,7 +385,7 @@ impl<'a> ReactorBuilderState<'a> {
     pub fn add_reaction(
         &mut self,
         name: &str,
-        reaction_fn: impl Into<BoxedReactionFn>,
+        reaction_fn: impl Into<runtime::BoxedReactionFn>,
     ) -> ReactionBuilderState {
         self.env
             .add_reaction(name, self.reactor_key, reaction_fn.into())
@@ -497,7 +496,7 @@ impl<'a> ReactorBuilderState<'a> {
         &mut self,
         port_a_key: TypedPortKey<T, Q1>,
         port_b_key: TypedPortKey<T, Q2>,
-        after: Option<Duration>,
+        after: Option<runtime::Duration>,
         physical: bool,
     ) -> Result<(), BuilderError> {
         self.env
@@ -509,7 +508,7 @@ impl<'a> ReactorBuilderState<'a> {
         &mut self,
         ports_from: impl Iterator<Item = TypedPortKey<T, Q1>>,
         ports_to: impl Iterator<Item = TypedPortKey<T, Q2>>,
-        after: Option<Duration>,
+        after: Option<runtime::Duration>,
         physical: bool,
     ) -> Result<(), BuilderError> {
         for (port_from, port_to) in ports_from.zip(ports_to) {

--- a/boomerang_builder/src/tests.rs
+++ b/boomerang_builder/src/tests.rs
@@ -1,6 +1,6 @@
-use std::{iter, time::Duration};
+use std::iter;
 
-use boomerang_runtime::{ActionCommon, ContextCommon};
+use boomerang_runtime::{ActionCommon, ContextCommon, Duration};
 
 use super::*;
 use crate::runtime;
@@ -77,7 +77,7 @@ fn test_dependency_use_on_logical_action() -> anyhow::Result<()> {
     let t = builder_main.add_timer(
         "t",
         TimerSpec {
-            period: Some(Duration::from_millis(2)),
+            period: Some(Duration::milliseconds(2)),
             offset: None,
         },
     )?;
@@ -95,15 +95,15 @@ fn test_dependency_use_on_logical_action() -> anyhow::Result<()> {
 
                     let (mut clock, mut a): (runtime::ActionRef<u32>, runtime::ActionRef<()>) = actions.partition_mut().unwrap();
 
-                    a.schedule(ctx, (), Some(Duration::from_millis(3))); // out of order on purpose
-                    a.schedule(ctx, (), Some(Duration::from_millis(1)));
-                    a.schedule(ctx, (), Some(Duration::from_millis(5)));
+                    a.schedule(ctx, (), Some(Duration::milliseconds(3))); // out of order on purpose
+                    a.schedule(ctx, (), Some(Duration::milliseconds(1)));
+                    a.schedule(ctx, (), Some(Duration::milliseconds(5)));
 
                     // not scheduled on milli 1 (action is)
-                    clock.schedule(ctx, 2, Some(Duration::from_millis(2)));
-                    clock.schedule(ctx, 3, Some(Duration::from_millis(3)));
-                    clock.schedule(ctx, 4, Some(Duration::from_millis(4)));
-                    clock.schedule(ctx, 5, Some(Duration::from_millis(5)));
+                    clock.schedule(ctx, 2, Some(Duration::milliseconds(2)));
+                    clock.schedule(ctx, 3, Some(Duration::milliseconds(3)));
+                    clock.schedule(ctx, 4, Some(Duration::milliseconds(4)));
+                    clock.schedule(ctx, 5, Some(Duration::milliseconds(5)));
                     // not scheduled on milli 6 (timer is)
                 }
             ),
@@ -203,7 +203,7 @@ fn test_dependency_use_on_logical_action() -> anyhow::Result<()> {
 
     let config = runtime::Config::default()
         .with_fast_forward(true)
-        .with_timeout(Duration::from_secs(1));
+        .with_timeout(Duration::seconds(1));
     let mut sched = runtime::Scheduler::new(env, reaction_graph, config);
     sched.event_loop();
 
@@ -226,7 +226,7 @@ fn test_dependency_use_accessible() -> anyhow::Result<()> {
                 .add_timer(
                     "t1",
                     TimerSpec {
-                        period: Some(Duration::from_millis(35)),
+                        period: Some(Duration::milliseconds(35)),
                         offset: None,
                     },
                 )
@@ -235,7 +235,7 @@ fn test_dependency_use_accessible() -> anyhow::Result<()> {
                 .add_timer(
                     "t2",
                     TimerSpec {
-                        period: Some(Duration::from_millis(70)),
+                        period: Some(Duration::milliseconds(70)),
                         offset: None,
                     },
                 )
@@ -248,7 +248,7 @@ fn test_dependency_use_accessible() -> anyhow::Result<()> {
                         let mut clock: runtime::OutputRef<u32> = mut_ports.partition_mut().unwrap();
                         assert_eq!(clock.name(), "clock");
                         *clock = Some(0);
-                        ctx.schedule_shutdown(Some(Duration::from_millis(140)));
+                        ctx.schedule_shutdown(Some(Duration::milliseconds(140)));
                     }),
                 )
                 .with_action(startup_action, 0, TriggerMode::TriggersOnly)?

--- a/boomerang_derive/src/util.rs
+++ b/boomerang_derive/src/util.rs
@@ -44,10 +44,10 @@ pub fn handle_duration(value: String) -> Option<Duration> {
 }
 
 /// Generate a TokenStream from an Option<Duration>
-pub fn duration_quote(duration: &std::time::Duration) -> proc_macro2::TokenStream {
+pub fn duration_quote(duration: &Duration) -> proc_macro2::TokenStream {
     let secs = duration.as_secs();
     let nanos = duration.subsec_nanos();
-    quote! {::std::time::Duration::new(#secs, #nanos)}
+    quote! {::boomerang::runtime::Duration::new(#secs as _, #nanos as _)}
 }
 
 pub struct OptionalDuration(pub Option<Duration>);

--- a/boomerang_runtime/Cargo.toml
+++ b/boomerang_runtime/Cargo.toml
@@ -26,6 +26,7 @@ serde = [
     #    "dep:serde_flexitos",
     #    "dep:linkme",
     #    "dep:paste",
+    "time/serde",
 ]
 
 [dependencies]
@@ -42,5 +43,6 @@ serde = { workspace = true, optional = true, features = ["derive"] }
 #serde_arrow = { workspace = true, optional = true, features = ["arrow-52"] }
 #serde_flexitos = { workspace = true, optional = true, features = ["id_trait"] }
 thiserror.workspace = true
+time.workspace = true
 tinymap.workspace = true
 tracing = { workspace = true }

--- a/boomerang_runtime/src/action/action_ref.rs
+++ b/boomerang_runtime/src/action/action_ref.rs
@@ -1,6 +1,4 @@
-use std::time::Duration;
-
-use crate::{event::AsyncEvent, Context, SendContext, Tag, Timestamp};
+use crate::{event::AsyncEvent, Context, Duration, SendContext, Tag};
 
 use super::{Action, ActionCommon, ActionKey, BaseAction, ReactorData};
 
@@ -36,7 +34,7 @@ impl<'a, T: ReactorData> ActionRef<'a, T> {
             context.tag.delay(tag_delay)
         } else {
             // Physical actions are scheduled at the current physical time + tag_delay
-            Tag::absolute(context.start_time, Timestamp::now().offset(tag_delay))
+            Tag::from_physical_time(context.start_time, std::time::Instant::now()).delay(tag_delay)
         };
 
         // Push the new value into the store
@@ -100,7 +98,8 @@ impl<T: ReactorData> AsyncActionRef<T> {
             AsyncEvent::logical(self.key, tag_delay, value)
         } else {
             // Physical actions are scheduled at the current physical time + tag_delay
-            let new_tag = Tag::absolute(context.start_time, Timestamp::now().offset(tag_delay));
+            let new_tag = Tag::from_physical_time(context.start_time, std::time::Instant::now())
+                .delay(tag_delay);
             tracing::info!(new_tag = %new_tag, key = ?self.key, "Scheduling Async PhysicalAction");
             AsyncEvent::physical(self.key, new_tag, value)
         };

--- a/boomerang_runtime/src/action/mod.rs
+++ b/boomerang_runtime/src/action/mod.rs
@@ -12,12 +12,9 @@
 //!     Action needs to be scheduled from a different thread. An `AsyncEvent` is created and pushed onto the `async_tx`
 //!     channel.
 
-use std::{
-    fmt::{Debug, Display},
-    time::Duration,
-};
+use std::fmt::{Debug, Display};
 
-use crate::{ReactorData, Tag};
+use crate::{Duration, ReactorData, Tag};
 
 mod action_ref;
 pub mod store;

--- a/boomerang_runtime/src/action/store.rs
+++ b/boomerang_runtime/src/action/store.rs
@@ -147,13 +147,13 @@ impl<T: ReactorData> BaseActionStore for ActionStore<T> {
 
 #[cfg(test)]
 mod tests {
-    use std::time::Duration;
+    use crate::Duration;
 
     use super::*;
 
     fn build_tags<const N: usize>() -> [Tag; N] {
         (0..N)
-            .map(|i| Tag::new(Duration::from_secs(i as u64), 0))
+            .map(|i| Tag::new(Duration::seconds(i as _), 0))
             .collect::<Vec<_>>()
             .try_into()
             .unwrap()
@@ -162,12 +162,12 @@ mod tests {
     #[test]
     fn test_action_entry_ordering() {
         let entry1 = ActionEntry::<()> {
-            tag: Tag::new(Duration::from_secs(1), 0),
+            tag: Tag::new(Duration::seconds(1), 0),
             sequence: 40,
             data: (),
         };
         let entry2 = ActionEntry::<()> {
-            tag: Tag::new(Duration::from_secs(1), 0),
+            tag: Tag::new(Duration::seconds(1), 0),
             sequence: 41,
             data: (),
         };
@@ -227,6 +227,6 @@ mod tests {
     #[test]
     fn test_empty_store() {
         let mut store = ActionStore::<u32>::new();
-        assert_eq!(store.get_current(Tag::new(Duration::from_secs(1), 0)), None);
+        assert_eq!(store.get_current(Tag::new(Duration::seconds(1), 0)), None);
     }
 }

--- a/boomerang_runtime/src/env/debug.rs
+++ b/boomerang_runtime/src/env/debug.rs
@@ -56,7 +56,7 @@ impl std::fmt::Debug for ReactionGraph {
             let e = self.action_triggers.iter().map(|(action_key, v)| {
                 let v = fmt::from_fn(|f| {
                     let e = v.iter().map(|(level, reaction_key)| {
-                        (format!("{level:?}"), format!("{reaction_key:?}"))
+                        (format!("{level}"), format!("{reaction_key:?}"))
                     });
                     f.debug_map().entries(e).finish()
                 });
@@ -70,7 +70,7 @@ impl std::fmt::Debug for ReactionGraph {
             let e = self.port_triggers.iter().map(|(port_key, v)| {
                 let v = fmt::from_fn(|f| {
                     let e = v.iter().map(|(level, reaction_key)| {
-                        (format!("{level:?}"), format!("{reaction_key:?}"))
+                        (format!("{level}"), format!("{reaction_key:?}"))
                     });
                     f.debug_map().entries(e).finish()
                 });

--- a/boomerang_runtime/src/env/mod.rs
+++ b/boomerang_runtime/src/env/mod.rs
@@ -16,6 +16,12 @@ impl std::fmt::Debug for Level {
     }
 }
 
+impl std::fmt::Display for Level {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "L{}", self.0)
+    }
+}
+
 impl From<usize> for Level {
     fn from(value: usize) -> Self {
         Self(value)

--- a/boomerang_runtime/src/event.rs
+++ b/boomerang_runtime/src/event.rs
@@ -1,9 +1,6 @@
-use std::{
-    fmt::{Debug, Display},
-    time::Duration,
-};
+use std::fmt::{Debug, Display};
 
-use crate::{ActionKey, LevelReactionKey, ReactionGraph, ReactionSet, ReactorData, Tag};
+use crate::{ActionKey, Duration, LevelReactionKey, ReactionGraph, ReactionSet, ReactorData, Tag};
 
 /// `ScheduledEvent` is used internally by the scheduler loop in the event queue. The dependent reactions are already expanded into a single reaction set.
 #[derive(Debug, Clone)]
@@ -114,7 +111,7 @@ impl Display for AsyncEvent {
                 write!(
                     f,
                     "AsyncLogical[delay={delay},key={key:?},value=..]",
-                    delay = delay.as_secs_f64()
+                    delay = delay.as_seconds_f64()
                 )
             }
             AsyncEvent::Physical { tag, key, value: _ } => {
@@ -166,7 +163,7 @@ impl AsyncEvent {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::{collections::BinaryHeap, time::Duration};
+    use std::collections::BinaryHeap;
 
     #[test]
     fn test_scheduled_event_order() {
@@ -175,30 +172,30 @@ mod tests {
         // Additionally, we want to ensure that shutdown events are processed last given multiple events with the same tag.
         let mut heap = BinaryHeap::new();
         heap.push(ScheduledEvent {
-            tag: Tag::new(Duration::from_secs(1), 0),
+            tag: Tag::new(Duration::seconds(1), 0),
             reactions: ReactionSet::default(),
             terminal: false,
         });
         heap.push(ScheduledEvent {
-            tag: Tag::new(Duration::from_secs(1), 0),
+            tag: Tag::new(Duration::seconds(1), 0),
             reactions: ReactionSet::default(),
             terminal: true,
         });
         heap.push(ScheduledEvent {
-            tag: Tag::new(Duration::from_secs(0), 0),
+            tag: Tag::new(Duration::seconds(0), 0),
             reactions: ReactionSet::default(),
             terminal: false,
         });
 
         // The top event should NOT be the shutdown event
         let ev0 = heap.pop().unwrap();
-        assert_eq!(ev0.tag.get_offset(), Duration::from_secs(0).into());
+        assert_eq!(ev0.tag.offset(), Duration::seconds(0));
         assert!(!ev0.terminal);
         let ev1 = heap.pop().unwrap();
         assert!(!ev1.terminal);
-        assert_eq!(ev1.tag.get_offset(), Duration::from_secs(1).into());
+        assert_eq!(ev1.tag.offset(), Duration::seconds(1));
         let ev2 = heap.pop().unwrap();
         assert!(ev2.terminal);
-        assert_eq!(ev2.tag.get_offset(), Duration::from_secs(1).into());
+        assert_eq!(ev2.tag.offset(), Duration::seconds(1));
     }
 }

--- a/boomerang_runtime/src/lib.rs
+++ b/boomerang_runtime/src/lib.rs
@@ -18,6 +18,8 @@ pub mod store;
 mod time;
 
 // Re-exports
+pub use ::time::Duration;
+
 pub use action::{Action, ActionCommon, ActionKey, ActionRef, AsyncActionRef, BaseAction};
 pub use context::*;
 use downcast_rs::Downcast;

--- a/boomerang_runtime/src/reaction.rs
+++ b/boomerang_runtime/src/reaction.rs
@@ -1,9 +1,9 @@
-use std::{fmt::Debug, sync::RwLock, time::Duration};
+use std::{fmt::Debug, sync::RwLock};
 
 use crate::{
     key_set::KeySet,
     refs::{Refs, RefsMut},
-    ActionRef, BaseAction, BasePort, BaseReactor, Context, Reactor, ReactorData,
+    ActionRef, BaseAction, BasePort, BaseReactor, Context, Duration, Reactor, ReactorData,
 };
 
 tinymap::key_type! { pub ReactionKey }

--- a/boomerang_runtime/src/store.rs
+++ b/boomerang_runtime/src/store.rs
@@ -294,7 +294,7 @@ impl Store {
 pub mod tests {
     use itertools::Itertools;
 
-    use crate::{action::ActionCommon, keepalive, ActionRef, InputRef, OutputRef, Timestamp};
+    use crate::{action::ActionCommon, keepalive, ActionRef, InputRef, OutputRef};
 
     use super::*;
 
@@ -307,7 +307,7 @@ pub mod tests {
 
         let contexts = [(
             reaction_key,
-            Context::new(Timestamp::now(), None, event_tx, shutdown_rx),
+            Context::new(std::time::Instant::now(), None, event_tx, shutdown_rx),
         )]
         .into_iter()
         .collect();
@@ -339,7 +339,7 @@ pub mod tests {
         }
         {
             let mut ctx_iter = unsafe { store.iter_borrow_storage(reaction_keys.iter().cloned()) };
-            let _res = ctx_iter.next().unwrap().trigger(Tag::now(Timestamp::now()));
+            let _res = ctx_iter.next().unwrap().trigger(Tag::ZERO);
         }
     }
 }

--- a/boomerang_runtime/src/time.rs
+++ b/boomerang_runtime/src/time.rs
@@ -1,164 +1,119 @@
-use std::time::{Duration, Instant};
+use time::ext::InstantExt;
 
-/// Timestamps are represented as the `Duration` since the UNIX epoch.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct Timestamp(Duration);
+use crate::Duration;
 
-impl From<Duration> for Timestamp {
-    fn from(duration: Duration) -> Self {
-        Self(duration)
-    }
-}
-
-impl Timestamp {
-    pub const ZERO: Self = Self(Duration::ZERO);
-    pub const MAX: Self = Self(Duration::MAX);
-
-    pub fn now() -> Self {
-        Self(
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .expect("System time before UNIX epoch"),
-        )
-    }
-
-    pub fn offset(&self, offset: impl Into<Duration>) -> Self {
-        Self(self.0 + offset.into())
-    }
-
-    pub fn checked_duration_since(&self, earlier: Self) -> Option<Duration> {
-        self.0.checked_sub(earlier.0)
-    }
-}
-
-impl std::ops::Sub for Timestamp {
-    type Output = Duration;
-
-    fn sub(self, rhs: Self) -> Self::Output {
-        self.0 - rhs.0
-    }
-}
-
-impl std::ops::Add<Timestamp> for Timestamp {
-    type Output = Self;
-
-    fn add(self, rhs: Timestamp) -> Self::Output {
-        Self(self.0 + rhs.0)
-    }
-}
-
+/// A tag is a logical time point in the system.
+///
+/// Internally, a Tag is represented as an offset from the origin of logical time, and a superdense-timestep.
+///
+/// Given a delay `d` and a `Tag` `g=(t, n)`, for any value of `n`, `g + d = (t, 0)`.
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Copy, Clone, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Tag {
     /// Offset from origin of logical time
-    offset: Timestamp,
+    offset: Duration,
     /// Superdense-timestep
-    micro_step: usize,
+    microstep: usize,
 }
 
 impl std::fmt::Display for Tag {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "[{:?}+{}]", self.offset, self.micro_step)
+        if self == &Tag::NEVER {
+            write!(f, "[NEVER]")
+        //} else if self == &Tag::ZERO {
+        //    write!(f, "[ZERO]")
+        } else if self == &Tag::FOREVER {
+            write!(f, "[FOREVER]")
+        } else {
+            write!(f, "[{}+{}]", self.offset, self.microstep)
+        }
     }
 }
 
 impl Tag {
     pub const NEVER: Self = Self {
-        offset: Timestamp::ZERO,
-        micro_step: 0,
+        offset: Duration::MIN,
+        microstep: 0,
+    };
+
+    pub const ZERO: Self = Self {
+        offset: Duration::ZERO,
+        microstep: 0,
     };
 
     pub const FOREVER: Self = Self {
-        offset: Timestamp::MAX,
-        micro_step: usize::MAX,
+        offset: Duration::MAX,
+        microstep: usize::MAX,
     };
 
     /// Create a new Tag given an offset from the origin, and a microstep
-    pub fn new(offset: impl Into<Timestamp>, micro_step: usize) -> Tag {
+    pub fn new(offset: impl Into<Duration>, microstep: usize) -> Tag {
         Self {
             offset: offset.into(),
-            micro_step,
+            microstep,
         }
     }
 
-    pub fn absolute(t0: Timestamp, instant: Timestamp) -> Self {
+    /// Create a new Tag given a physical time and the start time
+    pub fn from_physical_time(origin: std::time::Instant, time: std::time::Instant) -> Self {
         Self {
-            offset: (instant - t0).into(),
-            micro_step: 0,
-        }
-    }
-
-    pub fn now(t0: Timestamp) -> Self {
-        Self {
-            offset: (Timestamp::now() - t0).into(),
-            micro_step: 0,
-        }
-    }
-
-    /// Calculate a `Tag` relative to the given origin `t0`.
-    pub fn since(&self, t0: Timestamp) -> Self {
-        Self {
-            offset: self
-                .offset
-                .checked_duration_since(t0)
-                .unwrap_or_default()
-                .into(),
-            micro_step: 0,
+            offset: time.signed_duration_since(origin),
+            microstep: 0,
         }
     }
 
     /// Create a instant given the origin
-    pub fn to_logical_time(&self, origin: Timestamp) -> Timestamp {
+    pub fn to_logical_time(&self, origin: std::time::Instant) -> std::time::Instant {
         origin + self.offset
     }
 
-    /// Create a new Tag offset from the current.
-    pub fn delay(&self, offset: impl Into<Timestamp>) -> Self {
-        Self {
-            offset: self.offset + offset.into(),
-            micro_step: 0,
+    /// Create a new Tag strictly in the future from the current.
+    pub fn delay(&self, offset: Duration) -> Self {
+        if offset.is_zero() {
+            Self {
+                offset: self.offset,
+                microstep: self.microstep + 1,
+            }
+        } else {
+            Self {
+                offset: self.offset + offset,
+                microstep: 0,
+            }
         }
     }
 
-    pub fn get_offset(&self) -> Timestamp {
+    /// Create a new Tag offset strictly in the past from the current.
+    pub fn pre(&self, offset: Duration) -> Self {
+        if offset.is_zero() {
+            return self.decrement();
+        }
+
+        Self {
+            offset: self.offset - offset,
+            microstep: usize::MAX,
+        }
+    }
+
+    pub fn offset(&self) -> Duration {
         self.offset
     }
-}
 
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
-pub struct LogicalTime {
-    time_point: Instant,
-    micro_step: usize,
-}
-
-impl std::fmt::Display for LogicalTime {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "[{:?}+{}]", self.time_point.elapsed(), self.micro_step)
+    pub fn microstep(&self) -> usize {
+        self.microstep
     }
-}
 
-impl Default for LogicalTime {
-    fn default() -> Self {
-        Self {
-            time_point: Instant::now(),
-            micro_step: 0,
+    /// Create a new Tag minimally smaller than the current.
+    pub fn decrement(&self) -> Self {
+        if self.microstep == 0 {
+            Self {
+                offset: self.offset - Duration::nanoseconds(1),
+                microstep: usize::MAX,
+            }
+        } else {
+            Self {
+                offset: self.offset,
+                microstep: self.microstep - 1,
+            }
         }
-    }
-}
-
-impl LogicalTime {
-    pub fn get_time_point(&self) -> Instant {
-        self.time_point
-    }
-
-    pub fn get_micro_step(&self) -> usize {
-        self.micro_step
-    }
-
-    pub fn advance_to(&mut self, tag: &Tag) {
-        // assert!((self as &Self) < &tag.0);
-        // self.time_point = tag.offset;
-        self.micro_step = tag.micro_step;
     }
 }

--- a/examples/snake/src/main.rs
+++ b/examples/snake/src/main.rs
@@ -6,8 +6,6 @@ mod keyboard_events;
 
 #[cfg(not(windows))]
 mod reactor {
-    use std::time::Duration;
-
     use super::support::*;
     use crate::keyboard_events::{Key, KeyboardEvents, KeyboardEventsBuilder};
     use boomerang::prelude::*;
@@ -95,7 +93,7 @@ mod reactor {
 
             // schedule the first one, then it reschedules itself.
             self.screen_refresh
-                .schedule(ctx, (), Some(Duration::from_millis(1000)));
+                .schedule(ctx, (), Some(Duration::milliseconds(1000)));
         }
     }
 
@@ -113,8 +111,8 @@ mod reactor {
             state: &mut <SnakeBuilder as Reactor>::State,
         ) {
             // select a delay depending on the tempo
-            let delay = Duration::from_millis(400)
-                - (state.tempo_step * state.tempo).min(Duration::from_millis(300));
+            let delay = Duration::milliseconds(400)
+                - (state.tempo_step * state.tempo).min(Duration::milliseconds(300));
             self.screen_refresh.schedule(ctx, (), Some(delay));
         }
     }
@@ -224,12 +222,10 @@ mod reactor {
 
 #[cfg(not(windows))]
 fn main() {
-    use std::time::Duration;
-
     use reactor::{Snake, SnakeBuilder};
     let _ = boomerang_util::runner::build_and_run_reactor::<SnakeBuilder>(
         "snake",
-        Snake::new(32, Duration::from_millis(40), 2),
+        Snake::new(32, boomerang::runtime::Duration::milliseconds(40), 2),
     )
     .unwrap();
 }


### PR DESCRIPTION
Replace the usage of the `time` crate with the `Duration` type for improved time handling.