### PR TITLE
Refactor snake example for cross-platform compatibility

### DIFF
--- a/examples/snake/Cargo.toml
+++ b/examples/snake/Cargo.toml
@@ -13,10 +13,8 @@ boomerang_util = { workspace = true, features = ["runner"] }
 tracing = { workspace = true }
 
 # Deps for Snake example
-[target.'cfg(not(windows))'.dependencies]
 rand = { version = "0.8" }
-termcolor = { version = "1.2" }
-termion = { version = "2.0" }
+crossterm = { version = "0.28"}
 
 [dev-dependencies]
 tracing-subscriber = { workspace = true }

--- a/examples/snake/src/keyboard_events.rs
+++ b/examples/snake/src/keyboard_events.rs
@@ -1,13 +1,14 @@
 //! Capture asynchronous key presses, and sends them through an output port.
 use boomerang::prelude::*;
 
-use std::io::Stdout;
-pub use termion::event::Key;
-use termion::raw::{IntoRawMode, RawTerminal};
+use crossterm::{
+    event::{self, Event, KeyCode, KeyEvent, KeyModifiers},
+    terminal::{disable_raw_mode, enable_raw_mode},
+};
 
 #[derive(Default)]
 pub struct KeyboardEvents {
-    raw_terminal: Option<RawTerminal<Stdout>>,
+    raw_mode_enabled: bool,
 }
 
 impl std::fmt::Debug for KeyboardEvents {
@@ -25,18 +26,18 @@ impl std::fmt::Debug for KeyboardEvents {
 )]
 pub struct KeyboardEventsBuilder {
     /// The latest key press.
-    pub arrow_key_pressed: TypedPortKey<Key, Output>,
+    pub arrow_key_pressed: TypedPortKey<KeyEvent, Output>,
 
     #[reactor(action(min_delay = "10 msec"))]
-    key_press: TypedActionKey<Key, Physical>,
+    key_press: TypedActionKey<KeyEvent, Physical>,
 }
 
 #[derive(Reaction)]
 #[reaction(reactor = "KeyboardEventsBuilder")]
 struct ReactionKeyPress<'a> {
     #[reaction(triggers)]
-    key_press: runtime::ActionRef<'a, Key>,
-    arrow_key_pressed: runtime::OutputRef<'a, Key>,
+    key_press: runtime::ActionRef<'a, KeyEvent>,
+    arrow_key_pressed: runtime::OutputRef<'a, KeyEvent>,
 }
 
 impl<'a> runtime::Trigger<KeyboardEvents> for ReactionKeyPress<'a> {
@@ -51,42 +52,43 @@ struct ReactionShutdown;
 
 impl runtime::Trigger<KeyboardEvents> for ReactionShutdown {
     fn trigger(self, _ctx: &mut runtime::Context, state: &mut KeyboardEvents) {
-        drop(state.raw_terminal.take()); // exit raw mode
+        if state.raw_mode_enabled {
+            let _ = disable_raw_mode(); // exit raw mode
+            state.raw_mode_enabled = false;
+        }
     }
 }
 
 #[derive(Reaction)]
 #[reaction(reactor = "KeyboardEventsBuilder", triggers(startup))]
 struct ReactionStartup {
-    key_press: runtime::AsyncActionRef<Key>,
+    key_press: runtime::AsyncActionRef<KeyEvent>,
 }
 
 impl runtime::Trigger<KeyboardEvents> for ReactionStartup {
     fn trigger(self, ctx: &mut runtime::Context, state: &mut KeyboardEvents) {
-        let stdin = std::io::stdin();
-
         // enter raw mode, to get key presses one by one
-        // this will stay so until this variable is dropped
-        state.raw_terminal = Some(std::io::stdout().into_raw_mode().unwrap());
+        enable_raw_mode().unwrap();
+        state.raw_mode_enabled = true;
 
         let mut send_ctx = ctx.make_send_context();
 
         std::thread::spawn(move || {
-            use termion::input::TermRead;
-
-            for c in stdin.keys() {
-                match c.unwrap() {
-                    k @ (Key::Left | Key::Right | Key::Up | Key::Down) => {
-                        tracing::debug!("received {:?}", k);
-                        send_ctx.schedule_action_async(&self.key_press, k, None);
-                    }
-                    Key::Ctrl('c') => {
-                        tracing::debug!("Ctrl-C received, shutting down.");
-                        send_ctx.schedule_shutdown(None);
-                        break;
-                    }
-                    k => {
-                        tracing::trace!("received {:?}", k);
+            loop {
+                if let Ok(Event::Key(key_event)) = event::read() {
+                    match (key_event.code, key_event.modifiers) {
+                        (KeyCode::Left | KeyCode::Right | KeyCode::Up | KeyCode::Down, _) => {
+                            tracing::debug!("received {:?}", key_event);
+                            send_ctx.schedule_action_async(&self.key_press, key_event, None);
+                        }
+                        (KeyCode::Char('c'), KeyModifiers::CONTROL) => {
+                            tracing::debug!("Ctrl-C received, shutting down.");
+                            send_ctx.schedule_shutdown(None);
+                            break;
+                        }
+                        _ => {
+                            tracing::trace!("received {:?}", key_event);
+                        }
                     }
                 }
             }

--- a/examples/snake/src/keyboard_events.rs
+++ b/examples/snake/src/keyboard_events.rs
@@ -73,22 +73,20 @@ impl runtime::Trigger<KeyboardEvents> for ReactionStartup {
 
         let mut send_ctx = ctx.make_send_context();
 
-        std::thread::spawn(move || {
-            loop {
-                if let Ok(Event::Key(key_event)) = event::read() {
-                    match (key_event.code, key_event.modifiers) {
-                        (KeyCode::Left | KeyCode::Right | KeyCode::Up | KeyCode::Down, _) => {
-                            tracing::debug!("received {:?}", key_event);
-                            send_ctx.schedule_action_async(&self.key_press, key_event, None);
-                        }
-                        (KeyCode::Char('c'), KeyModifiers::CONTROL) => {
-                            tracing::debug!("Ctrl-C received, shutting down.");
-                            send_ctx.schedule_shutdown(None);
-                            break;
-                        }
-                        _ => {
-                            tracing::trace!("received {:?}", key_event);
-                        }
+        std::thread::spawn(move || loop {
+            if let Ok(Event::Key(key_event)) = event::read() {
+                match (key_event.code, key_event.modifiers) {
+                    (KeyCode::Left | KeyCode::Right | KeyCode::Up | KeyCode::Down, _) => {
+                        tracing::debug!("received {:?}", key_event);
+                        send_ctx.schedule_action_async(&self.key_press, key_event, None);
+                    }
+                    (KeyCode::Char('c'), KeyModifiers::CONTROL) => {
+                        tracing::debug!("Ctrl-C received, shutting down.");
+                        send_ctx.schedule_shutdown(None);
+                        break;
+                    }
+                    _ => {
+                        tracing::trace!("received {:?}", key_event);
                     }
                 }
             }

--- a/examples/snake/src/main.rs
+++ b/examples/snake/src/main.rs
@@ -1,14 +1,11 @@
-#[cfg(not(windows))]
+mod keyboard_events;
 mod support;
 
-#[cfg(not(windows))]
-mod keyboard_events;
-
-#[cfg(not(windows))]
 mod reactor {
     use super::support::*;
-    use crate::keyboard_events::{Key, KeyboardEvents, KeyboardEventsBuilder};
+    use crate::keyboard_events::{KeyboardEvents, KeyboardEventsBuilder};
     use boomerang::prelude::*;
+    use crossterm::event::{KeyCode, KeyEvent};
 
     #[derive(Reactor)]
     #[reactor(
@@ -163,7 +160,7 @@ mod reactor {
     #[reaction(reactor = "SnakeBuilder")]
     struct ReactionKeyboard<'a> {
         #[reaction(path = "keyboard.arrow_key_pressed")]
-        arrow_key_pressed: runtime::InputRef<'a, Key>,
+        arrow_key_pressed: runtime::InputRef<'a, KeyEvent>,
     }
 
     impl runtime::Trigger<Snake> for ReactionKeyboard<'_> {
@@ -173,11 +170,11 @@ mod reactor {
             state: &mut <SnakeBuilder as Reactor>::State,
         ) {
             // this might be overwritten several times, only committed on screen refreshes
-            state.pending_direction = match self.arrow_key_pressed.unwrap() {
-                Key::Left => Direction::Left,
-                Key::Right => Direction::Right,
-                Key::Up => Direction::Up,
-                Key::Down => Direction::Down,
+            state.pending_direction = match self.arrow_key_pressed.as_ref().map(|k| k.code) {
+                Some(KeyCode::Left) => Direction::Left,
+                Some(KeyCode::Right) => Direction::Right,
+                Some(KeyCode::Up) => Direction::Up,
+                Some(KeyCode::Down) => Direction::Down,
                 _ => unreachable!(),
             };
         }
@@ -223,7 +220,6 @@ mod reactor {
     }
 }
 
-#[cfg(not(windows))]
 fn main() {
     use reactor::{Snake, SnakeBuilder};
     let _ = boomerang_util::runner::build_and_run_reactor::<SnakeBuilder>(
@@ -232,6 +228,3 @@ fn main() {
     )
     .unwrap();
 }
-
-#[cfg(windows)]
-fn main() {}

--- a/examples/snake/src/support.rs
+++ b/examples/snake/src/support.rs
@@ -223,48 +223,32 @@ impl SnakeGrid {
 
 pub mod output {
     use super::*;
-    use std::io::{Error, ErrorKind, Result, Write};
-    use termcolor::{Buffer, BufferWriter, Color, ColorChoice, ColorSpec, WriteColor};
+    use std::io::{Result, Write};
+    use crossterm::{
+        cursor::MoveTo, execute, style::Stylize, terminal::{Clear, ClearType}
+    };
 
     pub fn paint_on_raw_console(grid: &SnakeGrid) {
         let str = format_for_raw_console(grid).unwrap();
-        let stdout = std::io::stdout();
-        let mut stdout = stdout.lock();
+        let mut stdout = std::io::stdout();
 
-        // this escape char clears the terminal
-        write!(stdout, "\x1B[2J\n\r{}", str).unwrap();
+        // Clear the terminal and write the new grid
+        execute!(stdout, Clear(ClearType::All), MoveTo(0, 0)).unwrap();
+        write!(stdout, "{}", str).unwrap();
         stdout.flush().unwrap();
     }
 
-    fn print_fence(buf: &mut Buffer, side: usize) -> Result<()> {
-        write!(buf, "+")?;
+    fn print_fence(buf: &mut String, side: usize) -> Result<()> {
+        buf.push('+');
         for _ in 0..side {
-            write!(buf, "~~")?;
+            buf.push_str("~~");
         }
-        write!(buf, "+\n\r")
-    }
-
-    fn write_colored(buf: &mut Buffer, string: &str, color: &ColorSpec) -> Result<()> {
-        buf.set_color(color)?;
-        write!(buf, "{}", string)?;
-        buf.set_color(&ColorSpec::new())
+        buf.push_str("+\n\r");
+        Ok(())
     }
 
     fn format_for_raw_console(grid: &SnakeGrid) -> Result<String> {
-        let bufwtr = BufferWriter::stdout(ColorChoice::Always);
-        let mut buf = bufwtr.buffer();
-
-        let snake_color = {
-            let mut it = ColorSpec::new();
-            it.set_fg(Some(Color::Green));
-            it
-        };
-
-        let food_color = {
-            let mut it = ColorSpec::new();
-            it.set_fg(Some(Color::Yellow));
-            it
-        };
+        let mut buf = String::new();
 
         print_fence(&mut buf, grid.grid_side())?;
 
@@ -273,20 +257,29 @@ pub mod output {
         // way vertical/horizontal speed is not warped.
 
         for row in 0..grid.grid_side() {
-            write!(&mut buf, "|").unwrap();
+            buf.push('|');
             for col in 0..grid.grid_side() {
-                match grid[cell(row, col)] {
-                    CellState::SnakeHead => write_colored(&mut buf, "@ ", &snake_color)?,
-                    CellState::Snake => write_colored(&mut buf, "o ", &snake_color)?,
-                    CellState::Food => write_colored(&mut buf, "x ", &food_color)?,
-                    CellState::Free => write!(&mut buf, "  ")?,
-                }
+                let cell_str = match grid[cell(row, col)] {
+                    CellState::SnakeHead => "@ ",
+                    CellState::Snake => "o ",
+                    CellState::Food => "x ",
+                    CellState::Free => "  ",
+                };
+                
+                // Colorize text based on cell state
+                let colored_str = match grid[cell(row, col)] {
+                    CellState::SnakeHead | CellState::Snake => cell_str.green(),
+                    CellState::Food => cell_str.yellow(),
+                    CellState::Free => cell_str.reset(),
+                };
+                
+                buf.push_str(&format!("{}", colored_str));
             }
-            write!(&mut buf, "|\n\r")?;
+            buf.push_str("|\n\r");
         }
 
         print_fence(&mut buf, grid.grid_side())?;
 
-        String::from_utf8(buf.into_inner()).map_err(|e| Error::new(ErrorKind::Other, e))
+        Ok(buf)
     }
 }

--- a/examples/snake/src/support.rs
+++ b/examples/snake/src/support.rs
@@ -223,10 +223,13 @@ impl SnakeGrid {
 
 pub mod output {
     use super::*;
-    use std::io::{Result, Write};
     use crossterm::{
-        cursor::MoveTo, execute, style::Stylize, terminal::{Clear, ClearType}
+        cursor::MoveTo,
+        execute,
+        style::Stylize,
+        terminal::{Clear, ClearType},
     };
+    use std::io::{Result, Write};
 
     pub fn paint_on_raw_console(grid: &SnakeGrid) {
         let str = format_for_raw_console(grid).unwrap();
@@ -265,14 +268,14 @@ pub mod output {
                     CellState::Food => "x ",
                     CellState::Free => "  ",
                 };
-                
+
                 // Colorize text based on cell state
                 let colored_str = match grid[cell(row, col)] {
                     CellState::SnakeHead | CellState::Snake => cell_str.green(),
                     CellState::Food => cell_str.yellow(),
                     CellState::Free => cell_str.reset(),
                 };
-                
+
                 buf.push_str(&format!("{}", colored_str));
             }
             buf.push_str("|\n\r");

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,3 +1,2 @@
 wrap_comments = true
 comment_width = 100
-normalize_comments = true


### PR DESCRIPTION
Replace the termion library with crossterm for improved cross-platform keyboard handling in the snake example and apply formatting improvements in the examples.