### PR TITLE
feat: wire physical event queue size into env builder

### DIFF
--- a/boomerang/Cargo.toml
+++ b/boomerang/Cargo.toml
@@ -38,7 +38,6 @@ boomerang_macros = { workspace = true }
 [dev-dependencies]
 boomerang_util = { path = "../boomerang_util", features = ["runner", "replay"] }
 criterion = "0.5"
-pprof = { version = "0.13", features = ["criterion", "flamegraph"] }
 serde = { workspace = true }
 tracing-subscriber = { workspace = true }
 tracing-tracy = { workspace = true }
@@ -47,6 +46,7 @@ tracing-tracy = { workspace = true }
 [target.'cfg(not(windows))'.dev-dependencies]
 termcolor = { version = "1.2" }
 rand = { version = "0.8" }
+pprof = { version = "0.13", features = ["criterion", "flamegraph"] }
 
 [[bench]]
 name = "ping_pong"

--- a/boomerang/benches/benchmark.rs
+++ b/boomerang/benches/benchmark.rs
@@ -48,10 +48,10 @@ fn bench(c: &mut Criterion) {
                             &mut env_builder,
                         )
                         .unwrap();
-                    let BuilderRuntimeParts { enclaves, .. } =
-                        env_builder.into_runtime_parts().unwrap();
-                    let (enclave_key, enclave) = enclaves.into_iter().next().unwrap();
                     let config = runtime::Config::default().with_fast_forward(true);
+                    let BuilderRuntimeParts { enclaves, .. } =
+                        env_builder.into_runtime_parts(&config).unwrap();
+                    let (enclave_key, enclave) = enclaves.into_iter().next().unwrap();
                     runtime::Scheduler::new(enclave_key, enclave, config)
                 },
                 |mut sched| {

--- a/boomerang/benches/physical_actions.rs
+++ b/boomerang/benches/physical_actions.rs
@@ -2,6 +2,7 @@
 
 use boomerang::prelude::*;
 use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion, Throughput};
+#[cfg(not(windows))]
 use pprof::criterion::{Output, PProfProfiler};
 use std::sync::{
     atomic::{AtomicUsize, Ordering},
@@ -101,6 +102,7 @@ fn bench(c: &mut Criterion) {
 
 fn criterion_config() -> Criterion {
     let mut criterion = Criterion::default();
+    #[cfg(not(windows))]
     if std::env::var_os("BOOMERANG_PROFILE").is_some() {
         criterion = criterion
             .with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)))

--- a/boomerang/benches/physical_actions.rs
+++ b/boomerang/benches/physical_actions.rs
@@ -1,82 +1,117 @@
 //! A benchmark to check the throughput of scheduling and processing async physical actions.
 
 use boomerang::prelude::*;
-use criterion::{criterion_group, criterion_main, Criterion};
-use std::thread::JoinHandle;
+use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion, Throughput};
+use pprof::criterion::{Output, PProfProfiler};
+use std::sync::{
+    atomic::{AtomicUsize, Ordering},
+    Arc,
+};
 
 #[derive(Debug, Default)]
 struct State {
-    thread: Option<JoinHandle<usize>>,
-    sent: usize,
-    received: usize,
+    received: Arc<AtomicUsize>,
 }
 
-/// The Run reaction starts a new thread that sends as many actions as possible until requested to shut down. Upon shutdown, it returns the number of actions sent.
 #[reactor(state = State)]
 fn AsyncCallback() -> impl Reactor {
     let a = builder.add_physical_action::<u32>("a", None)?;
 
     reaction! {
-        Run (startup) a {
-            // make sure to join the old thread first
-            if let Some(thread) = state.thread.take() {
-                thread.join().unwrap();
-            }
-
-            let send_ctx = ctx.make_send_context();
-            let a = a.to_async();
-
-            // start new thread
-            state.thread = Some(std::thread::spawn(move || {
-                let mut count = 0;
-                while !send_ctx.is_shutdown() {
-                    send_ctx.schedule_action_async(&a, 0u32, None);
-                    count += 1;
-                }
-                count
-            }));
-        }
-    }
-
-    reaction! {
         Proc (a) {
-            state.received += 1;
-        }
-    }
-
-    reaction! {
-        Shutdown (shutdown) {
-            if let Some(thread) = state.thread.take() {
-                state.sent = thread.join().unwrap();
-            }
+            state.received.fetch_add(1, Ordering::Relaxed);
         }
     }
 }
 
 fn bench(c: &mut Criterion) {
-    c.bench_function("Physical Actions", |b| {
-        b.iter_batched(
-            || {
-                let mut env_builder = EnvBuilder::new();
-                let reactor = AsyncCallback();
-                let _reactor = reactor
-                    .build("main", State::default(), None, None, false, &mut env_builder)
-                    .unwrap();
-                let BuilderRuntimeParts { enclaves, .. } =
-                    env_builder.into_runtime_parts().unwrap();
-                let (enclave_key, enclave) = enclaves.into_iter().next().unwrap();
-                let config = runtime::Config::default()
-                    .with_fast_forward(false)
-                    .with_timeout(runtime::Duration::seconds(1));
-                runtime::Scheduler::new(enclave_key, enclave, config)
-            },
-            |mut sched| {
-                sched.event_loop();
-            },
-            criterion::BatchSize::NumIterations(10),
-        );
-    });
+    let mut group = c.benchmark_group("physical_actions");
+    for count in [1_000, 10_000, 100_000] {
+        group.throughput(Throughput::Elements(count as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(count), &count, |b, &count| {
+            b.iter_batched(
+                || {
+                    let received = Arc::new(AtomicUsize::new(0));
+                    let mut env_builder = EnvBuilder::new();
+                    let reactor = AsyncCallback();
+                    let _reactor = reactor
+                        .build(
+                            "main",
+                            State {
+                                received: received.clone(),
+                            },
+                            None,
+                            None,
+                            false,
+                            &mut env_builder,
+                        )
+                        .unwrap();
+                    let action_key = env_builder
+                        .find_physical_action_by_fqn("main/a")
+                        .unwrap();
+                    let config = runtime::Config::default()
+                        .with_fast_forward(false)
+                        .with_keep_alive(true)
+                        .with_queue_size(65_536);
+                    let BuilderRuntimeParts { enclaves, aliases, .. } =
+                        env_builder.into_runtime_parts(&config).unwrap();
+                    let (enclave_key, enclave) = enclaves.into_iter().next().unwrap();
+                    let (action_enclave_key, action_key) = aliases.action_aliases[action_key];
+                    assert_eq!(
+                        action_enclave_key, enclave_key,
+                        "physical action enclave mismatch"
+                    );
+                    let send_ctx = enclave.create_send_context(enclave_key);
+                    let action_ref = enclave.create_async_action_ref::<u32>(action_key);
+                    let mut scheduler = runtime::Scheduler::new(enclave_key, enclave, config);
+                    let scheduler_thread = std::thread::spawn(move || {
+                        scheduler.event_loop();
+                    });
+
+                    (send_ctx, action_ref, scheduler_thread, received)
+                },
+                |(mut send_ctx, action_ref, scheduler_thread, received)| {
+                    for i in 0..count {
+                        let delay = runtime::Duration::nanoseconds(i as i64);
+                        let scheduled =
+                            send_ctx.schedule_action_async(&action_ref, 0u32, Some(delay));
+                        assert!(scheduled, "failed to schedule physical action");
+                    }
+
+                    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+                    while received.load(Ordering::Relaxed) < count {
+                        if std::time::Instant::now() >= deadline {
+                            panic!(
+                                "timed out waiting for physical actions (received {}, expected {})",
+                                received.load(Ordering::Relaxed),
+                                count
+                            );
+                        }
+                        std::thread::yield_now();
+                    }
+
+                    send_ctx.schedule_shutdown(None);
+                    scheduler_thread.join().unwrap();
+                },
+                BatchSize::SmallInput,
+            );
+        });
+    }
 }
 
-criterion_group!(benches, bench);
+fn criterion_config() -> Criterion {
+    let mut criterion = Criterion::default();
+    if std::env::var_os("BOOMERANG_PROFILE").is_some() {
+        criterion = criterion
+            .with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)))
+            .profile_time(Some(std::time::Duration::from_secs(5)));
+    }
+    criterion
+}
+
+criterion_group! {
+    name = benches;
+    config = criterion_config();
+    targets = bench
+}
 criterion_main!(benches);

--- a/boomerang/benches/ping_pong.rs
+++ b/boomerang/benches/ping_pong.rs
@@ -9,6 +9,7 @@
 
 use boomerang::prelude::*;
 use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion, Throughput};
+#[cfg(not(windows))]
 use pprof::criterion::{Output, PProfProfiler};
 
 #[derive(Debug)]
@@ -152,6 +153,7 @@ fn bench(c: &mut Criterion) {
 
 fn criterion_config() -> Criterion {
     let mut criterion = Criterion::default();
+    #[cfg(not(windows))]
     if std::env::var_os("BOOMERANG_PROFILE").is_some() {
         criterion = criterion.with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
     }

--- a/boomerang/benches/ping_pong.rs
+++ b/boomerang/benches/ping_pong.rs
@@ -117,13 +117,13 @@ fn bench(c: &mut Criterion) {
                     let _reactor = reactor
                         .build("main", (), None, None, false, &mut env_builder)
                         .unwrap();
+                    let config = runtime::Config::default().with_fast_forward(true);
                     let BuilderRuntimeParts {
                         enclaves,
                         aliases: _,
                         ..
-                    } = env_builder.into_runtime_parts().unwrap();
+                    } = env_builder.into_runtime_parts(&config).unwrap();
                     let (enclave_key, enclave) = enclaves.into_iter().next().unwrap();
-                    let config = runtime::Config::default().with_fast_forward(true);
                     runtime::Scheduler::new(enclave_key, enclave, config)
                 },
                 |mut sched| {

--- a/boomerang_builder/src/tests.rs
+++ b/boomerang_builder/src/tests.rs
@@ -155,7 +155,7 @@ fn test_reactions_startup_shutdown() {
 
     let BuilderRuntimeParts {
         enclaves, aliases, ..
-    } = env_builder.into_runtime_parts().unwrap();
+    } = env_builder.into_runtime_parts(&runtime::Config::default()).unwrap();
     let (_enclave_key, enclave) = enclaves.into_iter().next().unwrap();
     let r0_key = aliases.reaction_aliases[r0_key].1;
     let r1_key = aliases.reaction_aliases[r1_key].1;
@@ -217,7 +217,7 @@ fn test_actions1() {
     let _reactor_key = reactor_builder.finish().unwrap();
     let BuilderRuntimeParts {
         enclaves, aliases, ..
-    } = env_builder.into_runtime_parts().unwrap();
+    } = env_builder.into_runtime_parts(&runtime::Config::default()).unwrap();
     let (_enclave_key, enclave) = enclaves.into_iter().next().unwrap();
 
     let reaction_a = aliases.reaction_aliases[reaction_a].1;
@@ -367,7 +367,7 @@ fn test_nested_reactor() {
 
     let BuilderRuntimeParts {
         enclaves, aliases, ..
-    } = env_builder.into_runtime_parts().unwrap();
+    } = env_builder.into_runtime_parts(&runtime::Config::default()).unwrap();
     assert_eq!(enclaves.len(), 1);
 
     assert_eq!(
@@ -411,7 +411,7 @@ fn test_reaction_ports() -> anyhow::Result<()> {
 
     let BuilderRuntimeParts {
         enclaves, aliases, ..
-    } = env_builder.into_runtime_parts().unwrap();
+    } = env_builder.into_runtime_parts(&runtime::Config::default()).unwrap();
     assert_eq!(enclaves.len(), 1);
     let (_enclave_key, enclave) = enclaves.into_iter().next().unwrap();
 
@@ -534,7 +534,7 @@ fn test_dependency_use_on_logical_action() -> anyhow::Result<()> {
 
     let BuilderRuntimeParts {
         enclaves, aliases, ..
-    } = env_builder.into_runtime_parts()?;
+    } = env_builder.into_runtime_parts(&runtime::Config::default())?;
     assert_eq!(enclaves.len(), 1);
     let (enclave_key, enclave) = enclaves.into_iter().next().unwrap();
 
@@ -741,7 +741,7 @@ fn test_dependency_use_accessible() -> anyhow::Result<()> {
 
     let BuilderRuntimeParts {
         enclaves, aliases, ..
-    } = env_builder.into_runtime_parts()?;
+    } = env_builder.into_runtime_parts(&runtime::Config::default())?;
     let (enclave_key, enclave) = enclaves.into_iter().next().unwrap();
 
     // the Source startup reaction should trigger on startup and effect the clock port
@@ -843,7 +843,7 @@ fn test_enclave_partitioning() {
 
     let world = reactor_builder.finish().unwrap();
 
-    let builder_parts = env_builder.into_runtime_parts().unwrap();
+    let builder_parts = env_builder.into_runtime_parts(&runtime::Config::default()).unwrap();
     assert_eq!(builder_parts.enclaves.len(), 2, "Expected 2 enclaves");
 
     let (world_enclave, world_key) = builder_parts.aliases.reactor_aliases[world];
@@ -990,7 +990,7 @@ fn test_enclave2() {
         enclaves,
         aliases: _,
         ..
-    } = env_builder.into_runtime_parts().unwrap();
+    } = env_builder.into_runtime_parts(&runtime::Config::default()).unwrap();
     assert_eq!(enclaves.len(), 3);
 
     let config = runtime::Config::default()
@@ -1089,7 +1089,7 @@ fn test_port_binding() {
 
     let BuilderRuntimeParts {
         enclaves, aliases, ..
-    } = env_builder.into_runtime_parts().unwrap();
+    } = env_builder.into_runtime_parts(&runtime::Config::default()).unwrap();
     assert_eq!(enclaves.len(), 1);
     let (_enclave_key, enclave) = enclaves.into_iter().next().unwrap();
     assert_eq!(enclave.env.reactors.len(), 4);

--- a/boomerang_runtime/src/env/mod.rs
+++ b/boomerang_runtime/src/env/mod.rs
@@ -185,6 +185,22 @@ impl Default for Enclave {
 }
 
 impl Enclave {
+    pub fn with_event_q_size(physical_event_q_size: usize) -> Self {
+        let size = physical_event_q_size.max(1);
+        let (event_tx, event_rx) = kanal::bounded(size);
+        let (shutdown_tx, shutdown_rx) = keepalive::channel();
+        Self {
+            env: Default::default(),
+            graph: Default::default(),
+            event_tx,
+            event_rx,
+            downstream_enclaves: Default::default(),
+            upstream_enclaves: Default::default(),
+            shutdown_tx,
+            shutdown_rx,
+        }
+    }
+
     pub fn insert_reactor(
         &mut self,
         reactor: Box<dyn BaseReactor>,

--- a/boomerang_util/src/runner.rs
+++ b/boomerang_util/src/runner.rs
@@ -65,7 +65,7 @@ pub fn build_and_test_reactor<S: runtime::ReactorData, R: Reactor<S>>(
         aliases: _,
         ..
     } = env_builder
-        .into_runtime_parts()
+        .into_runtime_parts(&config)
         .context("Error building environment!")?;
 
     let envs_out = runtime::execute_enclaves(enclaves.into_iter(), config);
@@ -142,13 +142,18 @@ where
         println!("{env_builder:#?}");
     }
 
+    let config = runtime::Config {
+        fast_forward: args.fast_forward,
+        ..Default::default()
+    };
+
     let BuilderRuntimeParts {
         enclaves,
         aliases: _,
         #[cfg(feature = "replay")]
         replayers,
     } = env_builder
-        .into_runtime_parts()
+        .into_runtime_parts(&config)
         .context("Error building environment!")?;
 
     if args.print_debug_info {
@@ -160,11 +165,6 @@ where
         tracing::info!("Reading replay from {}", filename.display());
         runtime::replay::create_replayer(filename, replayers, &enclaves)?;
     }
-
-    let config = runtime::Config {
-        fast_forward: args.fast_forward,
-        ..Default::default()
-    };
 
     let _envs_out = runtime::execute_enclaves(enclaves.into_iter(), config);
 

--- a/examples/snake/src/keyboard.rs
+++ b/examples/snake/src/keyboard.rs
@@ -60,16 +60,16 @@ fn main() {
         .build("printer", (), None, None, false, &mut env_builder)
         .unwrap();
 
+    let config = runtime::Config::default()
+        .with_fast_forward(false)
+        .with_keep_alive(true);
     let BuilderRuntimeParts {
         enclaves,
         aliases: _,
         ..
-    } = env_builder.into_runtime_parts().unwrap();
+    } = env_builder.into_runtime_parts(&config).unwrap();
 
     let (enclave_key, enclave) = enclaves.into_iter().next().unwrap();
-    let config = runtime::Config::default()
-        .with_fast_forward(false)
-        .with_keep_alive(true);
     let mut sched = runtime::Scheduler::new(enclave_key, enclave, config);
     sched.event_loop();
 }


### PR DESCRIPTION
## Purpose
Enable runtime-configured physical event queue sizing end-to-end, so schedulers and benchmarks can size the async event channel appropriately.


## Changes
- Rewrote the physical_actions bench to actually work.
- Add enclave constructor that uses a configurable event queue size and thread it through builder/runtime parts.
- Simplify EnvBuilder runtime parts construction to accept a runtime config reference.
- Update benches, tests, and runner code to pass a config and (for the physical actions bench) use a larger queue size.
 
## Validation
- cargo bench -p boomerang --bench physical_actions