### PR TITLE
test(sync): add trace contracts and deduplicate requests

### DIFF
--- a/boomerang_federated/src/client.rs
+++ b/boomerang_federated/src/client.rs
@@ -393,6 +393,7 @@ pub struct RtiFederatedTimeBarrier {
     inbound: boomerang_runtime::FederatedInboundEndpointRegistry,
     faults: boomerang_runtime::FederatedFaultState,
     last_granted: Option<boomerang_runtime::Tag>,
+    pending_request: Option<WireTag>,
     stopped: bool,
     poll_interval: StdDuration,
 }
@@ -430,6 +431,7 @@ impl RtiFederatedTimeBarrier {
             inbound,
             faults,
             last_granted: None,
+            pending_request: None,
             stopped: false,
             poll_interval: StdDuration::from_millis(1),
         })
@@ -457,26 +459,51 @@ impl RtiFederatedTimeBarrier {
             return Ok(None);
         }
 
-        self.check_runtime_fault()?;
+        if let Err(error) = self.check_runtime_fault() {
+            self.pending_request = None;
+            return Err(error);
+        }
 
         let requested = WireTag::try_from(tag)?;
-        self.client.send(FederateToRti::Net {
-            federate_id: self.federate_id.clone(),
-            tag: requested,
-        })?;
+        if self.pending_request != Some(requested) {
+            self.client.send(FederateToRti::Net {
+                federate_id: self.federate_id.clone(),
+                tag: requested,
+            })?;
+            self.pending_request = Some(requested);
+        }
 
         loop {
             if let Ok(Some(event)) = event_rx.try_recv() {
                 return Ok(Some(event));
             }
 
-            let Some(message) = self.client.recv_timeout(self.poll_interval)? else {
+            let message = match self.client.recv_timeout(self.poll_interval) {
+                Ok(message) => message,
+                Err(error) => {
+                    self.pending_request = None;
+                    return Err(error);
+                }
+            };
+            let Some(message) = message else {
                 continue;
             };
             match message {
                 RtiToFederate::Tag { tag: granted } => {
-                    let runtime_tag = boomerang_runtime::Tag::try_from(granted)?;
+                    let runtime_tag = match boomerang_runtime::Tag::try_from(granted) {
+                        Ok(tag) => tag,
+                        Err(error) => {
+                            self.pending_request = None;
+                            return Err(error.into());
+                        }
+                    };
                     self.last_granted = Some(runtime_tag);
+                    if self
+                        .pending_request
+                        .is_some_and(|pending| granted >= pending)
+                    {
+                        self.pending_request = None;
+                    }
                     if granted >= requested {
                         return Ok(None);
                     }
@@ -488,16 +515,24 @@ impl RtiFederatedTimeBarrier {
                     tag,
                     payload,
                 } => {
-                    return self.schedule_inbound_msg(source, endpoint, tag, &payload, event_rx);
+                    let result =
+                        self.schedule_inbound_msg(source, endpoint, tag, &payload, event_rx);
+                    if result.is_err() {
+                        self.pending_request = None;
+                    }
+                    return result;
                 }
                 RtiToFederate::Stop => {
+                    self.pending_request = None;
                     self.stopped = true;
                     return Err(FederateClientError::RtiStopped);
                 }
                 RtiToFederate::Error { message } => {
+                    self.pending_request = None;
                     return Err(FederateClientError::RtiError { message });
                 }
                 RtiToFederate::Start { .. } => {
+                    self.pending_request = None;
                     return Err(FederateClientError::Protocol(
                         "unexpected duplicate Start frame".into(),
                     ));
@@ -539,6 +574,7 @@ impl RtiFederatedTimeBarrier {
         let stop_result = self.client.send(FederateToRti::Stop {
             federate_id: self.federate_id.clone(),
         });
+        self.pending_request = None;
         self.stopped = true;
         fault_result?;
         net_result?;
@@ -970,6 +1006,92 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn bridge_does_not_repeat_pending_net_after_inbound_interruption() {
+        let next_tag = WireTag::finite(1_000_000_000, 0);
+        let (client, rti) =
+            connect_client_with_fake_rti(fed("sink"), move |mut transport| async move {
+                assert!(matches!(
+                    recv_federate_to_rti(&mut transport).await,
+                    FederateToRti::Hello { federate_id, .. } if federate_id == fed("sink")
+                ));
+                send_rti_to_federate(
+                    &mut transport,
+                    RtiToFederate::Start {
+                        start_unix_epoch_ns: 0,
+                    },
+                )
+                .await;
+                assert_eq!(
+                    recv_federate_to_rti(&mut transport).await,
+                    FederateToRti::Net {
+                        federate_id: fed("sink"),
+                        tag: WireTag::ZERO,
+                    }
+                );
+                send_rti_to_federate(
+                    &mut transport,
+                    RtiToFederate::Msg {
+                        source: fed("source"),
+                        endpoint: protocol_endpoint(),
+                        tag: WireTag::ZERO,
+                        payload: b"42".to_vec(),
+                    },
+                )
+                .await;
+                assert_eq!(
+                    recv_federate_to_rti(&mut transport).await,
+                    FederateToRti::MsgAck {
+                        federate_id: fed("sink"),
+                        tag: WireTag::ZERO,
+                    }
+                );
+
+                send_rti_to_federate(&mut transport, RtiToFederate::Tag { tag: WireTag::ZERO })
+                    .await;
+                assert_eq!(
+                    recv_federate_to_rti(&mut transport).await,
+                    FederateToRti::Net {
+                        federate_id: fed("sink"),
+                        tag: next_tag,
+                    }
+                );
+                send_rti_to_federate(&mut transport, RtiToFederate::Tag { tag: next_tag }).await;
+            })
+            .await;
+
+        let (registry, event_rx, _action_key, _shutdown_tx, endpoint_key) =
+            inbound_registry_for_u32();
+        let mut inbound_route = route();
+        inbound_route.bind_inbound(endpoint_key);
+        let mut barrier = RtiFederatedTimeBarrier::new(
+            fed("sink"),
+            client,
+            [inbound_route],
+            registry,
+            boomerang_runtime::FederatedFaultState::default(),
+        )
+        .unwrap();
+
+        assert!(barrier
+            .wait_for_tag(boomerang_runtime::Tag::ZERO, &event_rx)
+            .unwrap()
+            .is_some());
+        assert!(barrier
+            .wait_for_tag(boomerang_runtime::Tag::ZERO, &event_rx)
+            .unwrap()
+            .is_none());
+        assert!(barrier
+            .wait_for_tag(
+                boomerang_runtime::Tag::new(boomerang_runtime::Duration::seconds(1), 0),
+                &event_rx,
+            )
+            .unwrap()
+            .is_none());
+
+        rti.await.unwrap();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn bridge_reports_rti_error_frame() {
         let (client, rti) =
             connect_client_with_fake_rti(fed("source"), |mut transport| async move {
@@ -1016,6 +1138,7 @@ mod tests {
             ),
             Err(error) if error.to_string().contains("boom")
         ));
+        assert_eq!(barrier.pending_request, None);
 
         rti.await.unwrap();
     }
@@ -1061,6 +1184,7 @@ mod tests {
         .unwrap();
 
         barrier.stop().unwrap();
+        assert_eq!(barrier.pending_request, None);
 
         rti.await.unwrap();
     }

--- a/boomerang_federated/src/client.rs
+++ b/boomerang_federated/src/client.rs
@@ -387,14 +387,23 @@ impl FederateClientRoute {
 #[cfg(feature = "runtime")]
 #[derive(Debug)]
 pub struct RtiFederatedTimeBarrier {
+    /// Stable protocol identity used for outgoing frames and inbound route validation.
     federate_id: FederateId,
+    /// Persistent ordered protocol connection to the RTI.
     client: FederateProtocolClient,
+    /// Federation route metadata keyed by its stable endpoint identifier.
     routes: BTreeMap<crate::EndpointId, FederateClientRoute>,
+    /// Runtime registry used to decode and schedule accepted inbound payloads.
     inbound: boomerang_runtime::FederatedInboundEndpointRegistry,
+    /// Shared terminal fault reported by the runtime endpoint workers, if any.
     faults: boomerang_runtime::FederatedFaultState,
+    /// Most recently accepted RTI grant, used to satisfy repeated or older requests locally.
     last_granted: Option<boomerang_runtime::Tag>,
+    /// Successfully queued `NET` request still awaiting a sufficient `TAG` response.
     pending_request: Option<WireTag>,
+    /// Whether this barrier has entered its terminal stopped state.
     stopped: bool,
+    /// Maximum time spent waiting for an RTI frame before checking scheduler events again.
     poll_interval: StdDuration,
 }
 

--- a/boomerang_federated/src/lib.rs
+++ b/boomerang_federated/src/lib.rs
@@ -11,6 +11,8 @@ pub mod runtime_bridge;
 pub mod session;
 #[cfg(feature = "runtime")]
 pub mod static_runner;
+#[cfg(test)]
+mod test_trace;
 pub mod transport;
 
 pub use client::{

--- a/boomerang_federated/src/session.rs
+++ b/boomerang_federated/src/session.rs
@@ -502,7 +502,9 @@ mod tests {
     use futures_util::{FutureExt, SinkExt, StreamExt};
 
     use super::*;
-    use crate::test_trace::{Trace, TraceActor, TraceEvent, TraceMessage, TracePattern};
+    use crate::test_trace::{
+        RecordingClientTransport, Trace, TraceActor, TraceEvent, TraceMessage, TracePattern,
+    };
     use crate::{
         in_memory_transport_pair, transport::InMemoryTransport, EndpointId, TopologyEdge,
         WireDelay, WireTag,
@@ -547,15 +549,6 @@ mod tests {
             .unwrap();
     }
 
-    async fn send_client_frame_traced(
-        transport: &mut InMemoryTransport<ProtocolFrame, ProtocolFrame>,
-        message: FederateToRti,
-        trace: &mut Trace,
-    ) {
-        trace.push(TraceEvent::client_to_rti(&message));
-        send_client_frame(transport, message).await;
-    }
-
     async fn recv_client_frame(
         transport: &mut InMemoryTransport<ProtocolFrame, ProtocolFrame>,
     ) -> RtiToFederate {
@@ -563,16 +556,6 @@ mod tests {
             ProtocolFrame::RtiToFederate(message) => message,
             other => panic!("expected RTI-to-federate frame, got {other:?}"),
         }
-    }
-
-    async fn recv_client_frame_traced(
-        transport: &mut InMemoryTransport<ProtocolFrame, ProtocolFrame>,
-        target: &FederateId,
-        trace: &mut Trace,
-    ) -> RtiToFederate {
-        let message = recv_client_frame(transport).await;
-        trace.push(TraceEvent::rti_to_client(target, &message));
-        message
     }
 
     fn recv_client_frame_now(
@@ -596,37 +579,12 @@ mod tests {
         );
     }
 
-    async fn expect_start_traced(
-        transport: &mut InMemoryTransport<ProtocolFrame, ProtocolFrame>,
-        target: &FederateId,
-        trace: &mut Trace,
-    ) {
-        assert_eq!(
-            recv_client_frame_traced(transport, target, trace).await,
-            RtiToFederate::Start {
-                start_unix_epoch_ns: 0,
-            }
-        );
-    }
-
     async fn expect_tag(
         transport: &mut InMemoryTransport<ProtocolFrame, ProtocolFrame>,
         tag: WireTag,
     ) {
         assert_eq!(
             recv_client_frame(transport).await,
-            RtiToFederate::Tag { tag }
-        );
-    }
-
-    async fn expect_tag_traced(
-        transport: &mut InMemoryTransport<ProtocolFrame, ProtocolFrame>,
-        target: &FederateId,
-        tag: WireTag,
-        trace: &mut Trace,
-    ) {
-        assert_eq!(
-            recv_client_frame_traced(transport, target, trace).await,
             RtiToFederate::Tag { tag }
         );
     }
@@ -657,67 +615,69 @@ mod tests {
     #[tokio::test]
     async fn session_routes_zero_tag_msg_and_unblocks_later_grants() {
         let topology = source_sink_topology();
-        let (mut source_client, mut sink_client, session) = spawn_session(topology.clone());
+        let (source_client, sink_client, session) = spawn_session(topology.clone());
         let source = fed("source");
         let sink = fed("sink");
         let endpoint = endpoint("source.out->sink.in");
-        let mut trace = Trace::default();
+        let trace = Trace::default();
+        let mut source_client =
+            RecordingClientTransport::new(source_client, source.clone(), trace.clone());
+        let mut sink_client =
+            RecordingClientTransport::new(sink_client, sink.clone(), trace.clone());
 
-        send_client_frame_traced(
-            &mut source_client,
-            FederateToRti::Hello {
+        source_client
+            .send(FederateToRti::Hello {
                 federate_id: source.clone(),
                 topology: topology.neighbors_for(&source),
-            },
-            &mut trace,
-        )
-        .await;
-        send_client_frame_traced(
-            &mut sink_client,
-            FederateToRti::Hello {
+            })
+            .await;
+        sink_client
+            .send(FederateToRti::Hello {
                 federate_id: sink.clone(),
                 topology: topology.neighbors_for(&sink),
-            },
-            &mut trace,
-        )
-        .await;
-        expect_start_traced(&mut source_client, &source, &mut trace).await;
-        expect_start_traced(&mut sink_client, &sink, &mut trace).await;
+            })
+            .await;
+        assert_eq!(
+            source_client.recv().await,
+            RtiToFederate::Start {
+                start_unix_epoch_ns: 0,
+            }
+        );
+        assert_eq!(
+            sink_client.recv().await,
+            RtiToFederate::Start {
+                start_unix_epoch_ns: 0,
+            }
+        );
 
-        send_client_frame_traced(
-            &mut sink_client,
-            FederateToRti::Net {
+        sink_client
+            .send(FederateToRti::Net {
                 federate_id: sink.clone(),
                 tag: WireTag::ZERO,
-            },
-            &mut trace,
-        )
-        .await;
-        send_client_frame_traced(
-            &mut source_client,
-            FederateToRti::Net {
+            })
+            .await;
+        source_client
+            .send(FederateToRti::Net {
                 federate_id: source.clone(),
                 tag: WireTag::ZERO,
-            },
-            &mut trace,
-        )
-        .await;
-        expect_tag_traced(&mut source_client, &source, WireTag::ZERO, &mut trace).await;
+            })
+            .await;
+        assert_eq!(
+            source_client.recv().await,
+            RtiToFederate::Tag { tag: WireTag::ZERO }
+        );
 
-        send_client_frame_traced(
-            &mut source_client,
-            FederateToRti::Msg {
+        source_client
+            .send(FederateToRti::Msg {
                 source: source.clone(),
                 target: sink.clone(),
                 endpoint: endpoint.clone(),
                 tag: WireTag::ZERO,
                 payload: b"hello".to_vec(),
-            },
-            &mut trace,
-        )
-        .await;
+            })
+            .await;
         assert_eq!(
-            recv_client_frame_traced(&mut sink_client, &sink, &mut trace).await,
+            sink_client.recv().await,
             RtiToFederate::Msg {
                 source: source.clone(),
                 endpoint: endpoint.clone(),
@@ -726,66 +686,47 @@ mod tests {
             }
         );
 
-        send_client_frame_traced(
-            &mut source_client,
-            FederateToRti::Net {
+        source_client
+            .send(FederateToRti::Net {
                 federate_id: source.clone(),
                 tag: WireTag::finite(0, 1),
-            },
-            &mut trace,
-        )
-        .await;
-        expect_tag_traced(
-            &mut source_client,
-            &source,
-            WireTag::finite(0, 1),
-            &mut trace,
-        )
-        .await;
-        send_client_frame_traced(
-            &mut sink_client,
-            FederateToRti::MsgAck {
+            })
+            .await;
+        assert_eq!(
+            source_client.recv().await,
+            RtiToFederate::Tag {
+                tag: WireTag::finite(0, 1),
+            }
+        );
+        sink_client
+            .send(FederateToRti::MsgAck {
                 federate_id: sink.clone(),
                 tag: WireTag::ZERO,
-            },
-            &mut trace,
-        )
-        .await;
-        expect_tag_traced(&mut sink_client, &sink, WireTag::ZERO, &mut trace).await;
-        send_client_frame_traced(
-            &mut sink_client,
-            FederateToRti::Ltc {
+            })
+            .await;
+        assert_eq!(
+            sink_client.recv().await,
+            RtiToFederate::Tag { tag: WireTag::ZERO }
+        );
+        sink_client
+            .send(FederateToRti::Ltc {
                 federate_id: sink.clone(),
                 tag: WireTag::ZERO,
-            },
-            &mut trace,
-        )
-        .await;
+            })
+            .await;
 
-        send_client_frame_traced(
-            &mut source_client,
-            FederateToRti::Stop {
+        source_client
+            .send(FederateToRti::Stop {
                 federate_id: source.clone(),
-            },
-            &mut trace,
-        )
-        .await;
-        send_client_frame_traced(
-            &mut sink_client,
-            FederateToRti::Stop {
+            })
+            .await;
+        sink_client
+            .send(FederateToRti::Stop {
                 federate_id: sink.clone(),
-            },
-            &mut trace,
-        )
-        .await;
-        assert_eq!(
-            recv_client_frame_traced(&mut source_client, &source, &mut trace).await,
-            RtiToFederate::Stop
-        );
-        assert_eq!(
-            recv_client_frame_traced(&mut sink_client, &sink, &mut trace).await,
-            RtiToFederate::Stop
-        );
+            })
+            .await;
+        assert_eq!(source_client.recv().await, RtiToFederate::Stop);
+        assert_eq!(sink_client.recv().await, RtiToFederate::Stop);
 
         use TraceActor::{Client, Rti};
         use TraceMessage::{Hello, Ltc, Msg, MsgAck, Net, Start, Stop, Tag};

--- a/boomerang_federated/src/session.rs
+++ b/boomerang_federated/src/session.rs
@@ -502,6 +502,7 @@ mod tests {
     use futures_util::{FutureExt, SinkExt, StreamExt};
 
     use super::*;
+    use crate::test_trace::{Trace, TraceActor, TraceEvent, TraceMessage, TracePattern};
     use crate::{
         in_memory_transport_pair, transport::InMemoryTransport, EndpointId, TopologyEdge,
         WireDelay, WireTag,
@@ -546,6 +547,15 @@ mod tests {
             .unwrap();
     }
 
+    async fn send_client_frame_traced(
+        transport: &mut InMemoryTransport<ProtocolFrame, ProtocolFrame>,
+        message: FederateToRti,
+        trace: &mut Trace,
+    ) {
+        trace.push(TraceEvent::client_to_rti(&message));
+        send_client_frame(transport, message).await;
+    }
+
     async fn recv_client_frame(
         transport: &mut InMemoryTransport<ProtocolFrame, ProtocolFrame>,
     ) -> RtiToFederate {
@@ -553,6 +563,16 @@ mod tests {
             ProtocolFrame::RtiToFederate(message) => message,
             other => panic!("expected RTI-to-federate frame, got {other:?}"),
         }
+    }
+
+    async fn recv_client_frame_traced(
+        transport: &mut InMemoryTransport<ProtocolFrame, ProtocolFrame>,
+        target: &FederateId,
+        trace: &mut Trace,
+    ) -> RtiToFederate {
+        let message = recv_client_frame(transport).await;
+        trace.push(TraceEvent::rti_to_client(target, &message));
+        message
     }
 
     fn recv_client_frame_now(
@@ -576,12 +596,37 @@ mod tests {
         );
     }
 
+    async fn expect_start_traced(
+        transport: &mut InMemoryTransport<ProtocolFrame, ProtocolFrame>,
+        target: &FederateId,
+        trace: &mut Trace,
+    ) {
+        assert_eq!(
+            recv_client_frame_traced(transport, target, trace).await,
+            RtiToFederate::Start {
+                start_unix_epoch_ns: 0,
+            }
+        );
+    }
+
     async fn expect_tag(
         transport: &mut InMemoryTransport<ProtocolFrame, ProtocolFrame>,
         tag: WireTag,
     ) {
         assert_eq!(
             recv_client_frame(transport).await,
+            RtiToFederate::Tag { tag }
+        );
+    }
+
+    async fn expect_tag_traced(
+        transport: &mut InMemoryTransport<ProtocolFrame, ProtocolFrame>,
+        target: &FederateId,
+        tag: WireTag,
+        trace: &mut Trace,
+    ) {
+        assert_eq!(
+            recv_client_frame_traced(transport, target, trace).await,
             RtiToFederate::Tag { tag }
         );
     }
@@ -616,45 +661,50 @@ mod tests {
         let source = fed("source");
         let sink = fed("sink");
         let endpoint = endpoint("source.out->sink.in");
+        let mut trace = Trace::default();
 
-        send_client_frame(
+        send_client_frame_traced(
             &mut source_client,
             FederateToRti::Hello {
                 federate_id: source.clone(),
                 topology: topology.neighbors_for(&source),
             },
+            &mut trace,
         )
         .await;
-        send_client_frame(
+        send_client_frame_traced(
             &mut sink_client,
             FederateToRti::Hello {
                 federate_id: sink.clone(),
                 topology: topology.neighbors_for(&sink),
             },
+            &mut trace,
         )
         .await;
-        expect_start(&mut source_client).await;
-        expect_start(&mut sink_client).await;
+        expect_start_traced(&mut source_client, &source, &mut trace).await;
+        expect_start_traced(&mut sink_client, &sink, &mut trace).await;
 
-        send_client_frame(
+        send_client_frame_traced(
             &mut sink_client,
             FederateToRti::Net {
                 federate_id: sink.clone(),
                 tag: WireTag::ZERO,
             },
+            &mut trace,
         )
         .await;
-        send_client_frame(
+        send_client_frame_traced(
             &mut source_client,
             FederateToRti::Net {
                 federate_id: source.clone(),
                 tag: WireTag::ZERO,
             },
+            &mut trace,
         )
         .await;
-        expect_tag(&mut source_client, WireTag::ZERO).await;
+        expect_tag_traced(&mut source_client, &source, WireTag::ZERO, &mut trace).await;
 
-        send_client_frame(
+        send_client_frame_traced(
             &mut source_client,
             FederateToRti::Msg {
                 source: source.clone(),
@@ -663,10 +713,11 @@ mod tests {
                 tag: WireTag::ZERO,
                 payload: b"hello".to_vec(),
             },
+            &mut trace,
         )
         .await;
         assert_eq!(
-            recv_client_frame(&mut sink_client).await,
+            recv_client_frame_traced(&mut sink_client, &sink, &mut trace).await,
             RtiToFederate::Msg {
                 source: source.clone(),
                 endpoint: endpoint.clone(),
@@ -675,48 +726,135 @@ mod tests {
             }
         );
 
-        send_client_frame(
+        send_client_frame_traced(
             &mut source_client,
             FederateToRti::Net {
                 federate_id: source.clone(),
                 tag: WireTag::finite(0, 1),
             },
+            &mut trace,
         )
         .await;
-        expect_tag(&mut source_client, WireTag::finite(0, 1)).await;
-        send_client_frame(
+        expect_tag_traced(
+            &mut source_client,
+            &source,
+            WireTag::finite(0, 1),
+            &mut trace,
+        )
+        .await;
+        send_client_frame_traced(
             &mut sink_client,
             FederateToRti::MsgAck {
                 federate_id: sink.clone(),
                 tag: WireTag::ZERO,
             },
+            &mut trace,
         )
         .await;
-        expect_tag(&mut sink_client, WireTag::ZERO).await;
-        send_client_frame(
+        expect_tag_traced(&mut sink_client, &sink, WireTag::ZERO, &mut trace).await;
+        send_client_frame_traced(
             &mut sink_client,
             FederateToRti::Ltc {
                 federate_id: sink.clone(),
                 tag: WireTag::ZERO,
             },
+            &mut trace,
         )
         .await;
 
-        send_client_frame(
+        send_client_frame_traced(
             &mut source_client,
             FederateToRti::Stop {
-                federate_id: source,
+                federate_id: source.clone(),
             },
+            &mut trace,
         )
         .await;
-        send_client_frame(&mut sink_client, FederateToRti::Stop { federate_id: sink }).await;
+        send_client_frame_traced(
+            &mut sink_client,
+            FederateToRti::Stop {
+                federate_id: sink.clone(),
+            },
+            &mut trace,
+        )
+        .await;
         assert_eq!(
-            recv_client_frame(&mut source_client).await,
+            recv_client_frame_traced(&mut source_client, &source, &mut trace).await,
             RtiToFederate::Stop
         );
         assert_eq!(
-            recv_client_frame(&mut sink_client).await,
+            recv_client_frame_traced(&mut sink_client, &sink, &mut trace).await,
             RtiToFederate::Stop
+        );
+
+        use TraceActor::{Client, Rti};
+        use TraceMessage::{Hello, Ltc, Msg, MsgAck, Net, Start, Stop, Tag};
+
+        trace.assert_exact(&[
+            TraceEvent::new(Client(source.clone()), Rti, Hello),
+            TraceEvent::new(Client(sink.clone()), Rti, Hello),
+            TraceEvent::new(Rti, Client(source.clone()), Start),
+            TraceEvent::new(Rti, Client(sink.clone()), Start),
+            TraceEvent::new(Client(sink.clone()), Rti, Net(WireTag::ZERO)),
+            TraceEvent::new(Client(source.clone()), Rti, Net(WireTag::ZERO)),
+            TraceEvent::new(Rti, Client(source.clone()), Tag(WireTag::ZERO)),
+            TraceEvent::new(
+                Client(source.clone()),
+                Rti,
+                Msg {
+                    tag: WireTag::ZERO,
+                    endpoint: endpoint.clone(),
+                },
+            ),
+            TraceEvent::new(
+                Rti,
+                Client(sink.clone()),
+                Msg {
+                    tag: WireTag::ZERO,
+                    endpoint: endpoint.clone(),
+                },
+            ),
+            TraceEvent::new(Client(source.clone()), Rti, Net(WireTag::finite(0, 1))),
+            TraceEvent::new(Rti, Client(source.clone()), Tag(WireTag::finite(0, 1))),
+            TraceEvent::new(Client(sink.clone()), Rti, MsgAck(WireTag::ZERO)),
+            TraceEvent::new(Rti, Client(sink.clone()), Tag(WireTag::ZERO)),
+            TraceEvent::new(Client(sink.clone()), Rti, Ltc(WireTag::ZERO)),
+            TraceEvent::new(Client(source.clone()), Rti, Stop),
+            TraceEvent::new(Client(sink.clone()), Rti, Stop),
+            TraceEvent::new(Rti, Client(source.clone()), Stop),
+            TraceEvent::new(Rti, Client(sink.clone()), Stop),
+        ]);
+
+        let source_tag = TracePattern::between(Rti, Client(source.clone()), Tag(WireTag::ZERO));
+        let source_msg = TracePattern::between(
+            Client(source.clone()),
+            Rti,
+            Msg {
+                tag: WireTag::ZERO,
+                endpoint: endpoint.clone(),
+            },
+        );
+        let forwarded_msg = TracePattern::between(
+            Rti,
+            Client(sink.clone()),
+            Msg {
+                tag: WireTag::ZERO,
+                endpoint: endpoint.clone(),
+            },
+        );
+        let target_ack = TracePattern::between(Client(sink.clone()), Rti, MsgAck(WireTag::ZERO));
+        let target_tag = TracePattern::between(Rti, Client(sink.clone()), Tag(WireTag::ZERO));
+
+        trace.assert_before(source_tag, source_msg);
+        trace.assert_before(forwarded_msg, target_ack.clone());
+        trace.assert_before(target_ack, target_tag);
+        trace.assert_before(
+            TracePattern::between(Client(source.clone()), Rti, Stop),
+            TracePattern::between(Rti, Client(source.clone()), Stop),
+        );
+        trace.assert_before(
+            TracePattern::between(Client(sink.clone()), Rti, Stop),
+            TracePattern::between(Rti, Client(sink.clone()), Stop),
         );
 
         drop(source_client);

--- a/boomerang_federated/src/session.rs
+++ b/boomerang_federated/src/session.rs
@@ -536,6 +536,19 @@ mod tests {
         )
     }
 
+    fn positive_delay_cycle_topology() -> FederatedTopology {
+        let a = fed("a");
+        let b = fed("b");
+        let delay = WireDelay::from_nanos(10);
+        FederatedTopology::with_edges(
+            [a.clone(), b.clone()],
+            [
+                TopologyEdge::new(a.clone(), b.clone(), endpoint("a.out->b.in"), delay),
+                TopologyEdge::new(b, a, endpoint("b.out->a.in"), delay),
+            ],
+        )
+    }
+
     async fn send_client_frame(
         transport: &mut InMemoryTransport<ProtocolFrame, ProtocolFrame>,
         message: FederateToRti,
@@ -576,16 +589,137 @@ mod tests {
     }
 
     fn spawn_session(topology: FederatedTopology) -> SessionFixture {
+        spawn_two_federate_session(topology, fed("source"), fed("sink"))
+    }
+
+    fn spawn_two_federate_session(
+        topology: FederatedTopology,
+        first: FederateId,
+        second: FederateId,
+    ) -> SessionFixture {
         let (source_client, source_rti) = in_memory_transport_pair();
         let (sink_client, sink_rti) = in_memory_transport_pair();
         let mut endpoints = BTreeMap::new();
-        endpoints.insert(fed("source"), session_endpoint(source_rti));
-        endpoints.insert(fed("sink"), session_endpoint(sink_rti));
+        endpoints.insert(first, session_endpoint(source_rti));
+        endpoints.insert(second, session_endpoint(sink_rti));
 
         let session = StaticRtiSession::new(topology, endpoints);
         let handle = tokio::spawn(session.run());
 
         (source_client, sink_client, handle)
+    }
+
+    #[tokio::test]
+    async fn session_positive_delay_cycle_progresses_with_bounded_control_trace() {
+        const ADVANCE_COUNT: usize = 3;
+        const FEDERATE_COUNT: usize = 2;
+        const CONTROL_EVENTS_PER_ADVANCE: usize = 3; // NET request, TAG grant, and LTC.
+        const FIXED_PROTOCOL_EVENTS: usize = 8; // Two each of Hello, Start, and both Stop directions.
+
+        let topology = positive_delay_cycle_topology();
+        let a = fed("a");
+        let b = fed("b");
+        let (a_client, b_client, session) =
+            spawn_two_federate_session(topology.clone(), a.clone(), b.clone());
+        let trace = Trace::default();
+        let mut a_client = RecordingClientTransport::new(a_client, a.clone(), trace.clone());
+        let mut b_client = RecordingClientTransport::new(b_client, b.clone(), trace.clone());
+
+        a_client
+            .send(FederateToRti::Hello {
+                federate_id: a.clone(),
+                topology: topology.neighbors_for(&a),
+            })
+            .await;
+        b_client
+            .send(FederateToRti::Hello {
+                federate_id: b.clone(),
+                topology: topology.neighbors_for(&b),
+            })
+            .await;
+        assert_eq!(
+            a_client.recv().await,
+            RtiToFederate::Start {
+                start_unix_epoch_ns: 0,
+            }
+        );
+        assert_eq!(
+            b_client.recv().await,
+            RtiToFederate::Start {
+                start_unix_epoch_ns: 0,
+            }
+        );
+
+        let requested_tags = [
+            WireTag::ZERO,
+            WireTag::finite(10, 0),
+            WireTag::finite(20, 0),
+        ];
+        for tag in requested_tags {
+            a_client
+                .send(FederateToRti::Net {
+                    federate_id: a.clone(),
+                    tag,
+                })
+                .await;
+            b_client
+                .send(FederateToRti::Net {
+                    federate_id: b.clone(),
+                    tag,
+                })
+                .await;
+            assert_eq!(a_client.recv().await, RtiToFederate::Tag { tag });
+            assert_eq!(b_client.recv().await, RtiToFederate::Tag { tag });
+            a_client
+                .send(FederateToRti::Ltc {
+                    federate_id: a.clone(),
+                    tag,
+                })
+                .await;
+            b_client
+                .send(FederateToRti::Ltc {
+                    federate_id: b.clone(),
+                    tag,
+                })
+                .await;
+        }
+
+        a_client
+            .send(FederateToRti::Stop {
+                federate_id: a.clone(),
+            })
+            .await;
+        b_client
+            .send(FederateToRti::Stop {
+                federate_id: b.clone(),
+            })
+            .await;
+        assert_eq!(a_client.recv().await, RtiToFederate::Stop);
+        assert_eq!(b_client.recv().await, RtiToFederate::Stop);
+
+        use FramePattern::{Ltc, Net, Tag};
+        for tag in requested_tags {
+            for federate in [&a, &b] {
+                trace.assert_count(TracePattern::client_to_rti(federate.clone(), Net(tag)), 1);
+                trace.assert_count(TracePattern::rti_to_client(federate.clone(), Tag(tag)), 1);
+                trace.assert_count(TracePattern::client_to_rti(federate.clone(), Ltc(tag)), 1);
+                trace.assert_before(
+                    TracePattern::client_to_rti(federate.clone(), Net(tag)),
+                    TracePattern::rti_to_client(federate.clone(), Tag(tag)),
+                );
+                trace.assert_before(
+                    TracePattern::rti_to_client(federate.clone(), Tag(tag)),
+                    TracePattern::client_to_rti(federate.clone(), Ltc(tag)),
+                );
+            }
+        }
+        trace.assert_len(
+            ADVANCE_COUNT * FEDERATE_COUNT * CONTROL_EVENTS_PER_ADVANCE + FIXED_PROTOCOL_EVENTS,
+        );
+
+        drop(a_client);
+        drop(b_client);
+        session.await.unwrap().unwrap();
     }
 
     #[tokio::test]

--- a/boomerang_federated/src/session.rs
+++ b/boomerang_federated/src/session.rs
@@ -502,9 +502,7 @@ mod tests {
     use futures_util::{FutureExt, SinkExt, StreamExt};
 
     use super::*;
-    use crate::test_trace::{
-        RecordingClientTransport, Trace, TraceActor, TraceEvent, TraceMessage, TracePattern,
-    };
+    use crate::test_trace::{FramePattern, RecordingClientTransport, Trace, TracePattern};
     use crate::{
         in_memory_transport_pair, transport::InMemoryTransport, EndpointId, TopologyEdge,
         WireDelay, WireTag,
@@ -728,74 +726,69 @@ mod tests {
         assert_eq!(source_client.recv().await, RtiToFederate::Stop);
         assert_eq!(sink_client.recv().await, RtiToFederate::Stop);
 
-        use TraceActor::{Client, Rti};
-        use TraceMessage::{Hello, Ltc, Msg, MsgAck, Net, Start, Stop, Tag};
+        use FramePattern::{Hello, Ltc, Msg, MsgAck, Net, Start, Stop, Tag};
 
         trace.assert_exact(&[
-            TraceEvent::new(Client(source.clone()), Rti, Hello),
-            TraceEvent::new(Client(sink.clone()), Rti, Hello),
-            TraceEvent::new(Rti, Client(source.clone()), Start),
-            TraceEvent::new(Rti, Client(sink.clone()), Start),
-            TraceEvent::new(Client(sink.clone()), Rti, Net(WireTag::ZERO)),
-            TraceEvent::new(Client(source.clone()), Rti, Net(WireTag::ZERO)),
-            TraceEvent::new(Rti, Client(source.clone()), Tag(WireTag::ZERO)),
-            TraceEvent::new(
-                Client(source.clone()),
-                Rti,
+            TracePattern::client_to_rti(source.clone(), Hello),
+            TracePattern::client_to_rti(sink.clone(), Hello),
+            TracePattern::rti_to_client(source.clone(), Start),
+            TracePattern::rti_to_client(sink.clone(), Start),
+            TracePattern::client_to_rti(sink.clone(), Net(WireTag::ZERO)),
+            TracePattern::client_to_rti(source.clone(), Net(WireTag::ZERO)),
+            TracePattern::rti_to_client(source.clone(), Tag(WireTag::ZERO)),
+            TracePattern::client_to_rti(
+                source.clone(),
                 Msg {
                     tag: WireTag::ZERO,
                     endpoint: endpoint.clone(),
                 },
             ),
-            TraceEvent::new(
-                Rti,
-                Client(sink.clone()),
+            TracePattern::rti_to_client(
+                sink.clone(),
                 Msg {
                     tag: WireTag::ZERO,
                     endpoint: endpoint.clone(),
                 },
             ),
-            TraceEvent::new(Client(source.clone()), Rti, Net(WireTag::finite(0, 1))),
-            TraceEvent::new(Rti, Client(source.clone()), Tag(WireTag::finite(0, 1))),
-            TraceEvent::new(Client(sink.clone()), Rti, MsgAck(WireTag::ZERO)),
-            TraceEvent::new(Rti, Client(sink.clone()), Tag(WireTag::ZERO)),
-            TraceEvent::new(Client(sink.clone()), Rti, Ltc(WireTag::ZERO)),
-            TraceEvent::new(Client(source.clone()), Rti, Stop),
-            TraceEvent::new(Client(sink.clone()), Rti, Stop),
-            TraceEvent::new(Rti, Client(source.clone()), Stop),
-            TraceEvent::new(Rti, Client(sink.clone()), Stop),
+            TracePattern::client_to_rti(source.clone(), Net(WireTag::finite(0, 1))),
+            TracePattern::rti_to_client(source.clone(), Tag(WireTag::finite(0, 1))),
+            TracePattern::client_to_rti(sink.clone(), MsgAck(WireTag::ZERO)),
+            TracePattern::rti_to_client(sink.clone(), Tag(WireTag::ZERO)),
+            TracePattern::client_to_rti(sink.clone(), Ltc(WireTag::ZERO)),
+            TracePattern::client_to_rti(source.clone(), Stop),
+            TracePattern::client_to_rti(sink.clone(), Stop),
+            TracePattern::rti_to_client(source.clone(), Stop),
+            TracePattern::rti_to_client(sink.clone(), Stop),
         ]);
 
-        let source_tag = TracePattern::between(Rti, Client(source.clone()), Tag(WireTag::ZERO));
-        let source_msg = TracePattern::between(
-            Client(source.clone()),
-            Rti,
+        let source_tag = TracePattern::rti_to_client(source.clone(), Tag(WireTag::ZERO));
+        let source_msg = TracePattern::client_to_rti(
+            source.clone(),
             Msg {
                 tag: WireTag::ZERO,
                 endpoint: endpoint.clone(),
             },
         );
-        let forwarded_msg = TracePattern::between(
-            Rti,
-            Client(sink.clone()),
+        let forwarded_msg = TracePattern::rti_to_client(
+            sink.clone(),
             Msg {
                 tag: WireTag::ZERO,
                 endpoint: endpoint.clone(),
             },
         );
-        let target_ack = TracePattern::between(Client(sink.clone()), Rti, MsgAck(WireTag::ZERO));
-        let target_tag = TracePattern::between(Rti, Client(sink.clone()), Tag(WireTag::ZERO));
+        let target_ack = TracePattern::client_to_rti(sink.clone(), MsgAck(WireTag::ZERO));
+        let target_tag = TracePattern::rti_to_client(sink.clone(), Tag(WireTag::ZERO));
 
         trace.assert_before(source_tag, source_msg);
         trace.assert_before(forwarded_msg, target_ack.clone());
         trace.assert_before(target_ack, target_tag);
         trace.assert_before(
-            TracePattern::between(Client(source.clone()), Rti, Stop),
-            TracePattern::between(Rti, Client(source.clone()), Stop),
+            TracePattern::client_to_rti(source.clone(), Stop),
+            TracePattern::rti_to_client(source.clone(), Stop),
         );
         trace.assert_before(
-            TracePattern::between(Client(sink.clone()), Rti, Stop),
-            TracePattern::between(Rti, Client(sink.clone()), Stop),
+            TracePattern::client_to_rti(sink.clone(), Stop),
+            TracePattern::rti_to_client(sink.clone(), Stop),
         );
 
         drop(source_client);

--- a/boomerang_federated/src/session.rs
+++ b/boomerang_federated/src/session.rs
@@ -499,7 +499,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use futures_util::{FutureExt, SinkExt, StreamExt};
+    use futures_util::{SinkExt, StreamExt};
 
     use super::*;
     use crate::test_trace::{FramePattern, RecordingClientTransport, Trace, TracePattern};
@@ -556,34 +556,12 @@ mod tests {
         }
     }
 
-    fn recv_client_frame_now(
-        transport: &mut InMemoryTransport<ProtocolFrame, ProtocolFrame>,
-    ) -> Option<RtiToFederate> {
-        match transport.1.next().now_or_never() {
-            Some(Some(Ok(ProtocolFrame::RtiToFederate(message)))) => Some(message),
-            Some(Some(Ok(other))) => panic!("expected RTI-to-federate frame, got {other:?}"),
-            Some(Some(Err(error))) => panic!("transport error while polling client frame: {error}"),
-            Some(None) => panic!("transport closed while polling client frame"),
-            None => None,
-        }
-    }
-
     async fn expect_start(transport: &mut InMemoryTransport<ProtocolFrame, ProtocolFrame>) {
         assert_eq!(
             recv_client_frame(transport).await,
             RtiToFederate::Start {
                 start_unix_epoch_ns: 0,
             }
-        );
-    }
-
-    async fn expect_tag(
-        transport: &mut InMemoryTransport<ProtocolFrame, ProtocolFrame>,
-        tag: WireTag,
-    ) {
-        assert_eq!(
-            recv_client_frame(transport).await,
-            RtiToFederate::Tag { tag }
         );
     }
 
@@ -799,62 +777,70 @@ mod tests {
     #[tokio::test]
     async fn session_blocks_pending_grant_behind_multiple_same_tag_messages() {
         let topology = source_sink_topology();
-        let (mut source_client, mut sink_client, session) = spawn_session(topology.clone());
+        let (source_client, sink_client, session) = spawn_session(topology.clone());
         let source = fed("source");
         let sink = fed("sink");
         let endpoint = endpoint("source.out->sink.in");
+        let trace = Trace::default();
+        let mut source_client =
+            RecordingClientTransport::new(source_client, source.clone(), trace.clone());
+        let mut sink_client =
+            RecordingClientTransport::new(sink_client, sink.clone(), trace.clone());
 
-        send_client_frame(
-            &mut source_client,
-            FederateToRti::Hello {
+        source_client
+            .send(FederateToRti::Hello {
                 federate_id: source.clone(),
                 topology: topology.neighbors_for(&source),
-            },
-        )
-        .await;
-        send_client_frame(
-            &mut sink_client,
-            FederateToRti::Hello {
+            })
+            .await;
+        sink_client
+            .send(FederateToRti::Hello {
                 federate_id: sink.clone(),
                 topology: topology.neighbors_for(&sink),
-            },
-        )
-        .await;
-        expect_start(&mut source_client).await;
-        expect_start(&mut sink_client).await;
+            })
+            .await;
+        assert_eq!(
+            source_client.recv().await,
+            RtiToFederate::Start {
+                start_unix_epoch_ns: 0,
+            }
+        );
+        assert_eq!(
+            sink_client.recv().await,
+            RtiToFederate::Start {
+                start_unix_epoch_ns: 0,
+            }
+        );
 
-        send_client_frame(
-            &mut sink_client,
-            FederateToRti::Net {
+        sink_client
+            .send(FederateToRti::Net {
                 federate_id: sink.clone(),
                 tag: WireTag::finite(0, 1),
-            },
-        )
-        .await;
-        send_client_frame(
-            &mut source_client,
-            FederateToRti::Net {
+            })
+            .await;
+        source_client
+            .send(FederateToRti::Net {
                 federate_id: source.clone(),
                 tag: WireTag::ZERO,
-            },
-        )
-        .await;
-        expect_tag(&mut source_client, WireTag::ZERO).await;
+            })
+            .await;
+        assert_eq!(
+            source_client.recv().await,
+            RtiToFederate::Tag { tag: WireTag::ZERO }
+        );
 
         for payload in [b"first".to_vec(), b"second".to_vec()] {
-            send_client_frame(
-                &mut source_client,
-                FederateToRti::Msg {
+            source_client
+                .send(FederateToRti::Msg {
                     source: source.clone(),
                     target: sink.clone(),
                     endpoint: endpoint.clone(),
                     tag: WireTag::ZERO,
                     payload: payload.clone(),
-                },
-            )
-            .await;
+                })
+                .await;
             assert_eq!(
-                recv_client_frame(&mut sink_client).await,
+                sink_client.recv().await,
                 RtiToFederate::Msg {
                     source: source.clone(),
                     endpoint: endpoint.clone(),
@@ -864,54 +850,85 @@ mod tests {
             );
         }
 
-        send_client_frame(
-            &mut source_client,
-            FederateToRti::Net {
+        source_client
+            .send(FederateToRti::Net {
                 federate_id: source.clone(),
                 tag: WireTag::finite(0, 2),
-            },
-        )
-        .await;
-        expect_tag(&mut source_client, WireTag::finite(0, 2)).await;
+            })
+            .await;
+        assert_eq!(
+            source_client.recv().await,
+            RtiToFederate::Tag {
+                tag: WireTag::finite(0, 2),
+            }
+        );
         tokio::task::yield_now().await;
-        assert_eq!(recv_client_frame_now(&mut sink_client), None);
+        assert_eq!(sink_client.recv_now(), None);
 
-        send_client_frame(
-            &mut sink_client,
-            FederateToRti::MsgAck {
+        let target_ack =
+            TracePattern::client_to_rti(sink.clone(), FramePattern::MsgAck(WireTag::ZERO));
+        let target_grant =
+            TracePattern::rti_to_client(sink.clone(), FramePattern::Tag(WireTag::finite(0, 1)));
+
+        sink_client
+            .send(FederateToRti::MsgAck {
                 federate_id: sink.clone(),
                 tag: WireTag::ZERO,
-            },
-        )
-        .await;
+            })
+            .await;
         tokio::task::yield_now().await;
-        assert_eq!(recv_client_frame_now(&mut sink_client), None);
-        send_client_frame(
-            &mut sink_client,
-            FederateToRti::MsgAck {
+        assert_eq!(sink_client.recv_now(), None);
+        trace.assert_count(target_ack.clone(), 1);
+        trace.assert_absent(target_grant.clone());
+
+        sink_client
+            .send(FederateToRti::MsgAck {
                 federate_id: sink.clone(),
                 tag: WireTag::ZERO,
-            },
-        )
-        .await;
-        expect_tag(&mut sink_client, WireTag::finite(0, 1)).await;
+            })
+            .await;
+        assert_eq!(
+            sink_client.recv().await,
+            RtiToFederate::Tag {
+                tag: WireTag::finite(0, 1),
+            }
+        );
 
-        send_client_frame(
-            &mut source_client,
-            FederateToRti::Stop {
-                federate_id: source,
+        source_client
+            .send(FederateToRti::Stop {
+                federate_id: source.clone(),
+            })
+            .await;
+        sink_client
+            .send(FederateToRti::Stop {
+                federate_id: sink.clone(),
+            })
+            .await;
+        assert_eq!(source_client.recv().await, RtiToFederate::Stop);
+        assert_eq!(sink_client.recv().await, RtiToFederate::Stop);
+
+        let source_message = TracePattern::client_to_rti(
+            source,
+            FramePattern::Msg {
+                tag: WireTag::ZERO,
+                endpoint: endpoint.clone(),
             },
-        )
-        .await;
-        send_client_frame(&mut sink_client, FederateToRti::Stop { federate_id: sink }).await;
-        assert_eq!(
-            recv_client_frame(&mut source_client).await,
-            RtiToFederate::Stop
         );
-        assert_eq!(
-            recv_client_frame(&mut sink_client).await,
-            RtiToFederate::Stop
+        let forwarded_message = TracePattern::rti_to_client(
+            sink,
+            FramePattern::Msg {
+                tag: WireTag::ZERO,
+                endpoint,
+            },
         );
+
+        trace.assert_count(source_message.clone(), 2);
+        trace.assert_count(forwarded_message.clone(), 2);
+        trace.assert_count(target_ack.clone(), 2);
+        trace.assert_count(target_grant.clone(), 1);
+        trace.assert_before(source_message, forwarded_message.clone());
+        trace.assert_before(forwarded_message, target_ack.clone());
+        trace.assert_before(target_ack, target_grant);
 
         drop(source_client);
         drop(sink_client);

--- a/boomerang_federated/src/test_trace.rs
+++ b/boomerang_federated/src/test_trace.rs
@@ -1,0 +1,321 @@
+use std::fmt::{self, Write as _};
+
+use crate::protocol::{EndpointId, FederateId, FederateToRti, RtiToFederate, WireTag};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum TraceActor {
+    Client(FederateId),
+    Rti,
+}
+
+impl fmt::Display for TraceActor {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Client(federate_id) => write!(f, "client({federate_id})"),
+            Self::Rti => f.write_str("rti"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum TraceMessage {
+    Hello,
+    Start,
+    Net(WireTag),
+    Tag(WireTag),
+    Msg { tag: WireTag, endpoint: EndpointId },
+    MsgAck(WireTag),
+    Ltc(WireTag),
+    Stop,
+    Error,
+}
+
+impl fmt::Display for TraceMessage {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Hello => f.write_str("Hello"),
+            Self::Start => f.write_str("Start"),
+            Self::Net(tag) => write!(f, "Net({tag})"),
+            Self::Tag(tag) => write!(f, "Tag({tag})"),
+            Self::Msg { tag, endpoint } => write!(f, "Msg({tag}, {endpoint})"),
+            Self::MsgAck(tag) => write!(f, "MsgAck({tag})"),
+            Self::Ltc(tag) => write!(f, "Ltc({tag})"),
+            Self::Stop => f.write_str("Stop"),
+            Self::Error => f.write_str("Error"),
+        }
+    }
+}
+
+impl From<&FederateToRti> for TraceMessage {
+    fn from(frame: &FederateToRti) -> Self {
+        match frame {
+            FederateToRti::Hello { .. } => Self::Hello,
+            FederateToRti::Net { tag, .. } => Self::Net(*tag),
+            FederateToRti::Ltc { tag, .. } => Self::Ltc(*tag),
+            FederateToRti::MsgAck { tag, .. } => Self::MsgAck(*tag),
+            FederateToRti::Msg { endpoint, tag, .. } => Self::Msg {
+                tag: *tag,
+                endpoint: endpoint.clone(),
+            },
+            FederateToRti::Stop { .. } => Self::Stop,
+        }
+    }
+}
+
+impl From<&RtiToFederate> for TraceMessage {
+    fn from(frame: &RtiToFederate) -> Self {
+        match frame {
+            RtiToFederate::Start { .. } => Self::Start,
+            RtiToFederate::Tag { tag } => Self::Tag(*tag),
+            RtiToFederate::Msg { endpoint, tag, .. } => Self::Msg {
+                tag: *tag,
+                endpoint: endpoint.clone(),
+            },
+            RtiToFederate::Stop => Self::Stop,
+            RtiToFederate::Error { .. } => Self::Error,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct TraceEvent {
+    pub(crate) from: TraceActor,
+    pub(crate) to: TraceActor,
+    pub(crate) message: TraceMessage,
+}
+
+impl TraceEvent {
+    pub(crate) fn client_to_rti(frame: &FederateToRti) -> Self {
+        let federate_id = match frame {
+            FederateToRti::Hello { federate_id, .. }
+            | FederateToRti::Net { federate_id, .. }
+            | FederateToRti::Ltc { federate_id, .. }
+            | FederateToRti::MsgAck { federate_id, .. }
+            | FederateToRti::Stop { federate_id } => federate_id,
+            FederateToRti::Msg { source, .. } => source,
+        };
+
+        Self {
+            from: TraceActor::Client(federate_id.clone()),
+            to: TraceActor::Rti,
+            message: frame.into(),
+        }
+    }
+
+    pub(crate) fn rti_to_client(target: &FederateId, frame: &RtiToFederate) -> Self {
+        Self {
+            from: TraceActor::Rti,
+            to: TraceActor::Client(target.clone()),
+            message: frame.into(),
+        }
+    }
+}
+
+impl fmt::Display for TraceEvent {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{} -> {} {}", self.from, self.to, self.message)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct TracePattern {
+    from: Option<TraceActor>,
+    to: Option<TraceActor>,
+    message: TraceMessage,
+}
+
+impl TracePattern {
+    pub(crate) fn message(message: TraceMessage) -> Self {
+        Self {
+            from: None,
+            to: None,
+            message,
+        }
+    }
+
+    pub(crate) fn between(from: TraceActor, to: TraceActor, message: TraceMessage) -> Self {
+        Self {
+            from: Some(from),
+            to: Some(to),
+            message,
+        }
+    }
+
+    fn matches(&self, event: &TraceEvent) -> bool {
+        self.from.as_ref().is_none_or(|from| from == &event.from)
+            && self.to.as_ref().is_none_or(|to| to == &event.to)
+            && self.message == event.message
+    }
+}
+
+impl fmt::Display for TracePattern {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match (&self.from, &self.to) {
+            (Some(from), Some(to)) => write!(f, "{from} -> {to} {}", self.message),
+            _ => self.message.fmt(f),
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct Trace {
+    events: Vec<TraceEvent>,
+}
+
+impl Trace {
+    pub(crate) fn push(&mut self, event: TraceEvent) {
+        self.events.push(event);
+    }
+
+    pub(crate) fn count(&self, mut predicate: impl FnMut(&TraceEvent) -> bool) -> usize {
+        self.events.iter().filter(|event| predicate(event)).count()
+    }
+
+    pub(crate) fn first_position(
+        &self,
+        mut predicate: impl FnMut(&TraceEvent) -> bool,
+    ) -> Option<usize> {
+        self.events.iter().position(&mut predicate)
+    }
+
+    #[track_caller]
+    pub(crate) fn assert_before(&self, first: TracePattern, second: TracePattern) {
+        let first_position = self.first_position(|event| first.matches(event));
+        let second_position = self.first_position(|event| second.matches(event));
+
+        assert!(
+            matches!((first_position, second_position), (Some(first), Some(second)) if first < second),
+            "expected `{first}` before `{second}`, found positions {first_position:?} and {second_position:?}\ntrace:\n{}",
+            self.normalized()
+        );
+    }
+
+    #[track_caller]
+    pub(crate) fn assert_count(&self, pattern: TracePattern, expected: usize) {
+        let actual = self.count(|event| pattern.matches(event));
+        assert_eq!(
+            actual,
+            expected,
+            "expected {expected} event(s) matching `{pattern}`, found {actual}\ntrace:\n{}",
+            self.normalized()
+        );
+    }
+
+    #[track_caller]
+    pub(crate) fn assert_absent(&self, pattern: TracePattern) {
+        let actual = self.count(|event| pattern.matches(event));
+        assert_eq!(
+            actual,
+            0,
+            "expected no events matching `{pattern}`, found {actual}\ntrace:\n{}",
+            self.normalized()
+        );
+    }
+
+    fn normalized(&self) -> String {
+        let mut output = String::new();
+        for (index, event) in self.events.iter().enumerate() {
+            writeln!(output, "{index}: {event}").expect("writing to a String cannot fail");
+        }
+        output
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn client(id: &str) -> TraceActor {
+        TraceActor::Client(FederateId::from(id))
+    }
+
+    #[test]
+    fn trace_normalizes_frames_to_semantic_fields() {
+        let first = FederateToRti::Msg {
+            source: FederateId::from("source"),
+            target: FederateId::from("target"),
+            endpoint: EndpointId::from("output"),
+            tag: WireTag::finite(10, 2),
+            payload: vec![1, 2, 3],
+        };
+        let second = FederateToRti::Msg {
+            source: FederateId::from("source"),
+            target: FederateId::from("another-target"),
+            endpoint: EndpointId::from("output"),
+            tag: WireTag::finite(10, 2),
+            payload: vec![9],
+        };
+
+        assert_eq!(
+            TraceEvent::client_to_rti(&first),
+            TraceEvent::client_to_rti(&second)
+        );
+
+        let start = RtiToFederate::Start {
+            start_unix_epoch_ns: 42,
+        };
+        assert_eq!(
+            TraceEvent::rti_to_client(&FederateId::from("target"), &start).message,
+            TraceMessage::Start
+        );
+    }
+
+    #[test]
+    fn trace_assertions_match_counts_absence_and_causal_order() {
+        let mut trace = Trace::default();
+        trace.push(TraceEvent {
+            from: client("source"),
+            to: TraceActor::Rti,
+            message: TraceMessage::Net(WireTag::ZERO),
+        });
+        trace.push(TraceEvent {
+            from: TraceActor::Rti,
+            to: client("source"),
+            message: TraceMessage::Tag(WireTag::ZERO),
+        });
+
+        assert_eq!(
+            trace.count(|event| matches!(event.message, TraceMessage::Net(_))),
+            1
+        );
+        assert_eq!(
+            trace.first_position(|event| matches!(event.message, TraceMessage::Tag(_))),
+            Some(1)
+        );
+        trace.assert_count(TracePattern::message(TraceMessage::Net(WireTag::ZERO)), 1);
+        trace.assert_absent(TracePattern::message(TraceMessage::Error));
+        trace.assert_before(
+            TracePattern::between(
+                client("source"),
+                TraceActor::Rti,
+                TraceMessage::Net(WireTag::ZERO),
+            ),
+            TracePattern::between(
+                TraceActor::Rti,
+                client("source"),
+                TraceMessage::Tag(WireTag::ZERO),
+            ),
+        );
+    }
+
+    #[test]
+    fn trace_assertion_failures_include_the_normalized_sequence() {
+        let mut trace = Trace::default();
+        trace.push(TraceEvent {
+            from: client("source"),
+            to: TraceActor::Rti,
+            message: TraceMessage::Net(WireTag::ZERO),
+        });
+
+        let panic = std::panic::catch_unwind(|| {
+            trace.assert_count(TracePattern::message(TraceMessage::Net(WireTag::ZERO)), 2);
+        })
+        .expect_err("the count assertion should fail");
+        let message = panic
+            .downcast::<String>()
+            .expect("assertion failures use an owned String message");
+
+        assert!(message.contains("expected 2 event(s) matching `Net([0ns+0])`, found 1"));
+        assert!(message.contains("0: client(source) -> rti Net([0ns+0])"));
+    }
+}

--- a/boomerang_federated/src/test_trace.rs
+++ b/boomerang_federated/src/test_trace.rs
@@ -1,6 +1,14 @@
-use std::fmt::{self, Write as _};
+use std::{
+    fmt::{self, Write as _},
+    sync::{Arc, Mutex},
+};
 
-use crate::protocol::{EndpointId, FederateId, FederateToRti, RtiToFederate, WireTag};
+use futures_util::{Sink, SinkExt, Stream, StreamExt};
+
+use crate::{
+    protocol::{EndpointId, FederateId, FederateToRti, ProtocolFrame, RtiToFederate, WireTag},
+    TransportError,
+};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum TraceActor {
@@ -161,25 +169,37 @@ impl fmt::Display for TracePattern {
     }
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug, Clone, Default)]
 pub(crate) struct Trace {
-    events: Vec<TraceEvent>,
+    events: Arc<Mutex<Vec<TraceEvent>>>,
 }
 
 impl Trace {
-    pub(crate) fn push(&mut self, event: TraceEvent) {
-        self.events.push(event);
+    pub(crate) fn push(&self, event: TraceEvent) {
+        self.events
+            .lock()
+            .expect("trace collector mutex should not be poisoned")
+            .push(event);
     }
 
     pub(crate) fn count(&self, mut predicate: impl FnMut(&TraceEvent) -> bool) -> usize {
-        self.events.iter().filter(|event| predicate(event)).count()
+        self.events
+            .lock()
+            .expect("trace collector mutex should not be poisoned")
+            .iter()
+            .filter(|event| predicate(event))
+            .count()
     }
 
     pub(crate) fn first_position(
         &self,
         mut predicate: impl FnMut(&TraceEvent) -> bool,
     ) -> Option<usize> {
-        self.events.iter().position(&mut predicate)
+        self.events
+            .lock()
+            .expect("trace collector mutex should not be poisoned")
+            .iter()
+            .position(&mut predicate)
     }
 
     #[track_caller]
@@ -196,12 +216,17 @@ impl Trace {
 
     #[track_caller]
     pub(crate) fn assert_exact(&self, expected: &[TraceEvent]) {
+        let events = self
+            .events
+            .lock()
+            .expect("trace collector mutex should not be poisoned");
+        let actual_trace = Self::normalized_events(&events);
         assert_eq!(
-            self.events.as_slice(),
+            events.as_slice(),
             expected,
             "expected exact trace:\n{}actual trace:\n{}",
             Self::normalized_events(expected),
-            self.normalized()
+            actual_trace
         );
     }
 
@@ -228,7 +253,12 @@ impl Trace {
     }
 
     fn normalized(&self) -> String {
-        Self::normalized_events(&self.events)
+        Self::normalized_events(
+            &self
+                .events
+                .lock()
+                .expect("trace collector mutex should not be poisoned"),
+        )
     }
 
     fn normalized_events(events: &[TraceEvent]) -> String {
@@ -240,9 +270,62 @@ impl Trace {
     }
 }
 
+/// Test-only client transport decorator that records successful protocol exchanges.
+pub(crate) struct RecordingClientTransport<S, St> {
+    sink: S,
+    stream: St,
+    federate_id: FederateId,
+    trace: Trace,
+}
+
+impl<S, St> RecordingClientTransport<S, St> {
+    pub(crate) fn new(transport: (S, St), federate_id: FederateId, trace: Trace) -> Self {
+        let (sink, stream) = transport;
+        Self {
+            sink,
+            stream,
+            federate_id,
+            trace,
+        }
+    }
+}
+
+impl<S, St> RecordingClientTransport<S, St>
+where
+    S: Sink<ProtocolFrame> + Unpin,
+    S::Error: fmt::Debug,
+    St: Stream<Item = Result<ProtocolFrame, TransportError>> + Unpin,
+{
+    pub(crate) async fn send(&mut self, message: FederateToRti) {
+        let event = TraceEvent::client_to_rti(&message);
+        self.sink
+            .send(ProtocolFrame::FederateToRti(message))
+            .await
+            .expect("recording client transport should send a protocol frame");
+        self.trace.push(event);
+    }
+
+    pub(crate) async fn recv(&mut self) -> RtiToFederate {
+        let frame = self
+            .stream
+            .next()
+            .await
+            .expect("recording client transport should remain open")
+            .expect("recording client transport should receive a protocol frame");
+        let message = match frame {
+            ProtocolFrame::RtiToFederate(message) => message,
+            other => panic!("expected RTI-to-federate frame, got {other:?}"),
+        };
+        self.trace
+            .push(TraceEvent::rti_to_client(&self.federate_id, &message));
+        message
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::in_memory_transport_pair;
 
     fn client(id: &str) -> TraceActor {
         TraceActor::Client(FederateId::from(id))
@@ -279,9 +362,55 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn recording_transport_captures_successful_protocol_frames() {
+        let federate_id = FederateId::from("source");
+        let (client, mut rti) = in_memory_transport_pair();
+        let trace = Trace::default();
+        let mut client = RecordingClientTransport::new(client, federate_id.clone(), trace.clone());
+
+        client
+            .send(FederateToRti::Net {
+                federate_id: federate_id.clone(),
+                tag: WireTag::ZERO,
+            })
+            .await;
+        assert_eq!(
+            rti.1.next().await.unwrap().unwrap(),
+            ProtocolFrame::FederateToRti(FederateToRti::Net {
+                federate_id: federate_id.clone(),
+                tag: WireTag::ZERO,
+            })
+        );
+
+        rti.0
+            .send(ProtocolFrame::RtiToFederate(RtiToFederate::Tag {
+                tag: WireTag::ZERO,
+            }))
+            .await
+            .unwrap();
+        assert_eq!(
+            client.recv().await,
+            RtiToFederate::Tag { tag: WireTag::ZERO }
+        );
+
+        trace.assert_exact(&[
+            TraceEvent::new(
+                TraceActor::Client(federate_id.clone()),
+                TraceActor::Rti,
+                TraceMessage::Net(WireTag::ZERO),
+            ),
+            TraceEvent::new(
+                TraceActor::Rti,
+                TraceActor::Client(federate_id),
+                TraceMessage::Tag(WireTag::ZERO),
+            ),
+        ]);
+    }
+
     #[test]
     fn trace_assertions_match_counts_absence_and_causal_order() {
-        let mut trace = Trace::default();
+        let trace = Trace::default();
         trace.push(TraceEvent {
             from: client("source"),
             to: TraceActor::Rti,
@@ -331,7 +460,7 @@ mod tests {
 
     #[test]
     fn trace_assertion_failures_include_the_normalized_sequence() {
-        let mut trace = Trace::default();
+        let trace = Trace::default();
         trace.push(TraceEvent {
             from: client("source"),
             to: TraceActor::Rti,

--- a/boomerang_federated/src/test_trace.rs
+++ b/boomerang_federated/src/test_trace.rs
@@ -1,3 +1,19 @@
+//! Test-only protocol tracing for federated coordination contracts.
+//!
+//! The recorder retains each successful transport exchange as its original
+//! [`ProtocolFrame`]. Assertions project those frames into [`FramePattern`] values so tests can
+//! describe coordination semantics without depending on payloads, redundant participant fields,
+//! or other protocol details that are irrelevant to the contract under test.
+//!
+//! Use [`TracePattern::client_to_rti`] and [`TracePattern::rti_to_client`] when actor identity and
+//! direction are part of the contract. Use [`TracePattern::message`] only when they deliberately
+//! are not. Prefer causal and count assertions for concurrent behavior; reserve
+//! [`Trace::assert_exact`] for deterministic, hand-driven exchanges.
+//!
+//! [`RecordingClientTransport`] is a test seam, not a durable federation recording format. A
+//! production recorder will need stable deployment identities, an accepted-ingress capture point,
+//! and a versioned serialization contract.
+
 use std::{
     fmt::{self, Write as _},
     sync::{Arc, Mutex},
@@ -25,7 +41,12 @@ impl fmt::Display for TraceActor {
     }
 }
 
-/// Lossy semantic projection used only to match and display recorded protocol frames.
+/// Lossy semantic projection used to match and display recorded protocol frames.
+///
+/// Patterns intentionally retain only fields that express the synchronization contract. For
+/// example, a message pattern keeps its logical tag and endpoint but ignores its payload and
+/// source/target fields. Add a field here only when tests must distinguish it semantically; the
+/// lossless frame remains available in the private recorded event.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum FramePattern {
     Hello,
@@ -80,6 +101,10 @@ impl fmt::Display for FramePattern {
     }
 }
 
+/// One losslessly captured frame and the client transport on which it was observed.
+///
+/// Direction is derived from the [`ProtocolFrame`] variant rather than stored separately, keeping
+/// the recorded representation faithful to the protocol types.
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct TraceEvent {
     client_id: FederateId,
@@ -114,6 +139,10 @@ impl fmt::Display for TraceEvent {
     }
 }
 
+/// An assertion pattern combining optional actor constraints with a semantic frame pattern.
+///
+/// Direction-specific constructors constrain both actors. [`Self::message`] matches the frame on
+/// any recorded client transport in either direction.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct TracePattern {
     from: Option<TraceActor>,
@@ -122,6 +151,7 @@ pub(crate) struct TracePattern {
 }
 
 impl TracePattern {
+    /// Matches a semantic frame regardless of its actors or direction.
     pub(crate) fn message(frame: FramePattern) -> Self {
         Self {
             from: None,
@@ -130,10 +160,12 @@ impl TracePattern {
         }
     }
 
+    /// Matches a frame sent from `client_id` to the RTI.
     pub(crate) fn client_to_rti(client_id: FederateId, frame: FramePattern) -> Self {
         Self::between(TraceActor::Client(client_id), TraceActor::Rti, frame)
     }
 
+    /// Matches a frame sent from the RTI to `client_id`.
     pub(crate) fn rti_to_client(client_id: FederateId, frame: FramePattern) -> Self {
         Self::between(TraceActor::Rti, TraceActor::Client(client_id), frame)
     }
@@ -163,6 +195,11 @@ impl fmt::Display for TracePattern {
     }
 }
 
+/// Shared, insertion-ordered collection of recorded protocol frames.
+///
+/// Clones refer to the same collection, allowing independently owned recording transports to
+/// contribute to one scenario trace. The mutex preserves each observed insertion, but concurrent
+/// tasks may interleave; assertions should encode only ordering that the scenario guarantees.
 #[derive(Debug, Clone, Default)]
 pub(crate) struct Trace {
     events: Arc<Mutex<Vec<TraceEvent>>>,
@@ -193,6 +230,9 @@ impl Trace {
             .position(|event| pattern.matches(event))
     }
 
+    /// Asserts that the first match for `first` occurs before the first match for `second`.
+    ///
+    /// The assertion also fails if either pattern is absent.
     #[track_caller]
     pub(crate) fn assert_before(&self, first: TracePattern, second: TracePattern) {
         let first_position = self.first_position(&first);
@@ -205,6 +245,10 @@ impl Trace {
         );
     }
 
+    /// Asserts that the complete trace matches `expected` in order with no extra events.
+    ///
+    /// This is intended for deterministic exchanges. Concurrent scenarios should normally use
+    /// causal, count, and absence assertions instead of imposing an incidental total order.
     #[track_caller]
     pub(crate) fn assert_exact(&self, expected: &[TracePattern]) {
         let events = self
@@ -225,6 +269,7 @@ impl Trace {
         );
     }
 
+    /// Asserts the number of events matching `pattern` across the complete trace.
     #[track_caller]
     pub(crate) fn assert_count(&self, pattern: TracePattern, expected: usize) {
         let actual = self.count(&pattern);
@@ -236,6 +281,7 @@ impl Trace {
         );
     }
 
+    /// Asserts that no event matches `pattern`.
     #[track_caller]
     pub(crate) fn assert_absent(&self, pattern: TracePattern) {
         let actual = self.count(&pattern);
@@ -274,6 +320,10 @@ impl Trace {
 }
 
 /// Test-only client transport decorator that records successful protocol exchanges.
+///
+/// The decorator owns one client's sink and stream and appends lossless [`ProtocolFrame`] values
+/// to a shared [`Trace`]. It intentionally exposes only the typed client-side `send` and `recv`
+/// operations needed by session tests rather than implementing the underlying transport traits.
 pub(crate) struct RecordingClientTransport<S, St> {
     sink: S,
     stream: St,
@@ -282,6 +332,7 @@ pub(crate) struct RecordingClientTransport<S, St> {
 }
 
 impl<S, St> RecordingClientTransport<S, St> {
+    /// Wraps a client transport pair and identifies its observations in `trace`.
     pub(crate) fn new(transport: (S, St), federate_id: FederateId, trace: Trace) -> Self {
         let (sink, stream) = transport;
         Self {
@@ -299,6 +350,9 @@ where
     S::Error: fmt::Debug,
     St: Stream<Item = Result<ProtocolFrame, TransportError>> + Unpin,
 {
+    /// Sends a client frame and records it after the underlying sink accepts it.
+    ///
+    /// A failed send panics through the test helper and is not recorded.
     pub(crate) async fn send(&mut self, message: FederateToRti) {
         let frame = ProtocolFrame::FederateToRti(message);
         self.sink
@@ -309,6 +363,11 @@ where
             .push(TraceEvent::new(self.federate_id.clone(), frame));
     }
 
+    /// Receives and records the next decoded frame, then returns its RTI-to-client message.
+    ///
+    /// End-of-stream and transport errors panic without recording an event. A successfully decoded
+    /// frame is recorded before its direction is checked, so a client-to-RTI frame received on this
+    /// stream appears in diagnostics before the helper panics.
     pub(crate) async fn recv(&mut self) -> RtiToFederate {
         let frame = self
             .stream

--- a/boomerang_federated/src/test_trace.rs
+++ b/boomerang_federated/src/test_trace.rs
@@ -19,7 +19,7 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-use futures_util::{Sink, SinkExt, Stream, StreamExt};
+use futures_util::{FutureExt, Sink, SinkExt, Stream, StreamExt};
 
 use crate::{
     protocol::{EndpointId, FederateId, FederateToRti, ProtocolFrame, RtiToFederate, WireTag},
@@ -350,6 +350,15 @@ where
     S::Error: fmt::Debug,
     St: Stream<Item = Result<ProtocolFrame, TransportError>> + Unpin,
 {
+    fn record_received(&self, frame: ProtocolFrame) -> RtiToFederate {
+        self.trace
+            .push(TraceEvent::new(self.federate_id.clone(), frame.clone()));
+        match frame {
+            ProtocolFrame::RtiToFederate(message) => message,
+            other => panic!("expected RTI-to-federate frame, got {other:?}"),
+        }
+    }
+
     /// Sends a client frame and records it after the underlying sink accepts it.
     ///
     /// A failed send panics through the test helper and is not recorded.
@@ -375,11 +384,21 @@ where
             .await
             .expect("recording client transport should remain open")
             .expect("recording client transport should receive a protocol frame");
-        self.trace
-            .push(TraceEvent::new(self.federate_id.clone(), frame.clone()));
-        match frame {
-            ProtocolFrame::RtiToFederate(message) => message,
-            other => panic!("expected RTI-to-federate frame, got {other:?}"),
+        self.record_received(frame)
+    }
+
+    /// Records and returns the next immediately available RTI-to-client message.
+    ///
+    /// Returns `None` when the stream is pending. Closed streams, transport errors, and frames in
+    /// the wrong direction have the same failure behavior as [`Self::recv`].
+    pub(crate) fn recv_now(&mut self) -> Option<RtiToFederate> {
+        match self.stream.next().now_or_never() {
+            Some(Some(Ok(frame))) => Some(self.record_received(frame)),
+            Some(Some(Err(error))) => {
+                panic!("recording client transport should receive a protocol frame: {error}")
+            }
+            Some(None) => panic!("recording client transport should remain open"),
+            None => None,
         }
     }
 }

--- a/boomerang_federated/src/test_trace.rs
+++ b/boomerang_federated/src/test_trace.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) enum TraceActor {
+enum TraceActor {
     Client(FederateId),
     Rti,
 }
@@ -25,8 +25,9 @@ impl fmt::Display for TraceActor {
     }
 }
 
+/// Lossy semantic projection used only to match and display recorded protocol frames.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) enum TraceMessage {
+pub(crate) enum FramePattern {
     Hello,
     Start,
     Net(WireTag),
@@ -38,7 +39,32 @@ pub(crate) enum TraceMessage {
     Error,
 }
 
-impl fmt::Display for TraceMessage {
+impl FramePattern {
+    fn from_frame(frame: &ProtocolFrame) -> Self {
+        match frame {
+            ProtocolFrame::FederateToRti(FederateToRti::Hello { .. }) => Self::Hello,
+            ProtocolFrame::FederateToRti(FederateToRti::Net { tag, .. }) => Self::Net(*tag),
+            ProtocolFrame::FederateToRti(FederateToRti::Ltc { tag, .. }) => Self::Ltc(*tag),
+            ProtocolFrame::FederateToRti(FederateToRti::MsgAck { tag, .. }) => Self::MsgAck(*tag),
+            ProtocolFrame::FederateToRti(FederateToRti::Msg { endpoint, tag, .. })
+            | ProtocolFrame::RtiToFederate(RtiToFederate::Msg { endpoint, tag, .. }) => Self::Msg {
+                tag: *tag,
+                endpoint: endpoint.clone(),
+            },
+            ProtocolFrame::FederateToRti(FederateToRti::Stop { .. })
+            | ProtocolFrame::RtiToFederate(RtiToFederate::Stop) => Self::Stop,
+            ProtocolFrame::RtiToFederate(RtiToFederate::Start { .. }) => Self::Start,
+            ProtocolFrame::RtiToFederate(RtiToFederate::Tag { tag }) => Self::Tag(*tag),
+            ProtocolFrame::RtiToFederate(RtiToFederate::Error { .. }) => Self::Error,
+        }
+    }
+
+    fn matches(&self, frame: &ProtocolFrame) -> bool {
+        self == &Self::from_frame(frame)
+    }
+}
+
+impl fmt::Display for FramePattern {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Hello => f.write_str("Hello"),
@@ -54,78 +80,37 @@ impl fmt::Display for TraceMessage {
     }
 }
 
-impl From<&FederateToRti> for TraceMessage {
-    fn from(frame: &FederateToRti) -> Self {
-        match frame {
-            FederateToRti::Hello { .. } => Self::Hello,
-            FederateToRti::Net { tag, .. } => Self::Net(*tag),
-            FederateToRti::Ltc { tag, .. } => Self::Ltc(*tag),
-            FederateToRti::MsgAck { tag, .. } => Self::MsgAck(*tag),
-            FederateToRti::Msg { endpoint, tag, .. } => Self::Msg {
-                tag: *tag,
-                endpoint: endpoint.clone(),
-            },
-            FederateToRti::Stop { .. } => Self::Stop,
-        }
-    }
-}
-
-impl From<&RtiToFederate> for TraceMessage {
-    fn from(frame: &RtiToFederate) -> Self {
-        match frame {
-            RtiToFederate::Start { .. } => Self::Start,
-            RtiToFederate::Tag { tag } => Self::Tag(*tag),
-            RtiToFederate::Msg { endpoint, tag, .. } => Self::Msg {
-                tag: *tag,
-                endpoint: endpoint.clone(),
-            },
-            RtiToFederate::Stop => Self::Stop,
-            RtiToFederate::Error { .. } => Self::Error,
-        }
-    }
-}
-
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct TraceEvent {
-    pub(crate) from: TraceActor,
-    pub(crate) to: TraceActor,
-    pub(crate) message: TraceMessage,
+struct TraceEvent {
+    client_id: FederateId,
+    frame: ProtocolFrame,
 }
 
 impl TraceEvent {
-    pub(crate) fn new(from: TraceActor, to: TraceActor, message: TraceMessage) -> Self {
-        Self { from, to, message }
+    fn new(client_id: FederateId, frame: ProtocolFrame) -> Self {
+        Self { client_id, frame }
     }
 
-    pub(crate) fn client_to_rti(frame: &FederateToRti) -> Self {
-        let federate_id = match frame {
-            FederateToRti::Hello { federate_id, .. }
-            | FederateToRti::Net { federate_id, .. }
-            | FederateToRti::Ltc { federate_id, .. }
-            | FederateToRti::MsgAck { federate_id, .. }
-            | FederateToRti::Stop { federate_id } => federate_id,
-            FederateToRti::Msg { source, .. } => source,
-        };
-
-        Self {
-            from: TraceActor::Client(federate_id.clone()),
-            to: TraceActor::Rti,
-            message: frame.into(),
-        }
-    }
-
-    pub(crate) fn rti_to_client(target: &FederateId, frame: &RtiToFederate) -> Self {
-        Self {
-            from: TraceActor::Rti,
-            to: TraceActor::Client(target.clone()),
-            message: frame.into(),
+    fn actors(&self) -> (TraceActor, TraceActor) {
+        match &self.frame {
+            ProtocolFrame::FederateToRti(_) => {
+                (TraceActor::Client(self.client_id.clone()), TraceActor::Rti)
+            }
+            ProtocolFrame::RtiToFederate(_) => {
+                (TraceActor::Rti, TraceActor::Client(self.client_id.clone()))
+            }
         }
     }
 }
 
 impl fmt::Display for TraceEvent {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{} -> {} {}", self.from, self.to, self.message)
+        let (from, to) = self.actors();
+        write!(
+            f,
+            "{from} -> {to} {}",
+            FramePattern::from_frame(&self.frame)
+        )
     }
 }
 
@@ -133,38 +118,47 @@ impl fmt::Display for TraceEvent {
 pub(crate) struct TracePattern {
     from: Option<TraceActor>,
     to: Option<TraceActor>,
-    message: TraceMessage,
+    frame: FramePattern,
 }
 
 impl TracePattern {
-    pub(crate) fn message(message: TraceMessage) -> Self {
+    pub(crate) fn message(frame: FramePattern) -> Self {
         Self {
             from: None,
             to: None,
-            message,
+            frame,
         }
     }
 
-    pub(crate) fn between(from: TraceActor, to: TraceActor, message: TraceMessage) -> Self {
+    pub(crate) fn client_to_rti(client_id: FederateId, frame: FramePattern) -> Self {
+        Self::between(TraceActor::Client(client_id), TraceActor::Rti, frame)
+    }
+
+    pub(crate) fn rti_to_client(client_id: FederateId, frame: FramePattern) -> Self {
+        Self::between(TraceActor::Rti, TraceActor::Client(client_id), frame)
+    }
+
+    fn between(from: TraceActor, to: TraceActor, frame: FramePattern) -> Self {
         Self {
             from: Some(from),
             to: Some(to),
-            message,
+            frame,
         }
     }
 
     fn matches(&self, event: &TraceEvent) -> bool {
-        self.from.as_ref().is_none_or(|from| from == &event.from)
-            && self.to.as_ref().is_none_or(|to| to == &event.to)
-            && self.message == event.message
+        let (from, to) = event.actors();
+        self.from.as_ref().is_none_or(|expected| expected == &from)
+            && self.to.as_ref().is_none_or(|expected| expected == &to)
+            && self.frame.matches(&event.frame)
     }
 }
 
 impl fmt::Display for TracePattern {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match (&self.from, &self.to) {
-            (Some(from), Some(to)) => write!(f, "{from} -> {to} {}", self.message),
-            _ => self.message.fmt(f),
+            (Some(from), Some(to)) => write!(f, "{from} -> {to} {}", self.frame),
+            _ => self.frame.fmt(f),
         }
     }
 }
@@ -175,37 +169,34 @@ pub(crate) struct Trace {
 }
 
 impl Trace {
-    pub(crate) fn push(&self, event: TraceEvent) {
+    fn push(&self, event: TraceEvent) {
         self.events
             .lock()
             .expect("trace collector mutex should not be poisoned")
             .push(event);
     }
 
-    pub(crate) fn count(&self, mut predicate: impl FnMut(&TraceEvent) -> bool) -> usize {
+    fn count(&self, pattern: &TracePattern) -> usize {
         self.events
             .lock()
             .expect("trace collector mutex should not be poisoned")
             .iter()
-            .filter(|event| predicate(event))
+            .filter(|event| pattern.matches(event))
             .count()
     }
 
-    pub(crate) fn first_position(
-        &self,
-        mut predicate: impl FnMut(&TraceEvent) -> bool,
-    ) -> Option<usize> {
+    fn first_position(&self, pattern: &TracePattern) -> Option<usize> {
         self.events
             .lock()
             .expect("trace collector mutex should not be poisoned")
             .iter()
-            .position(&mut predicate)
+            .position(|event| pattern.matches(event))
     }
 
     #[track_caller]
     pub(crate) fn assert_before(&self, first: TracePattern, second: TracePattern) {
-        let first_position = self.first_position(|event| first.matches(event));
-        let second_position = self.first_position(|event| second.matches(event));
+        let first_position = self.first_position(&first);
+        let second_position = self.first_position(&second);
 
         assert!(
             matches!((first_position, second_position), (Some(first), Some(second)) if first < second),
@@ -215,24 +206,28 @@ impl Trace {
     }
 
     #[track_caller]
-    pub(crate) fn assert_exact(&self, expected: &[TraceEvent]) {
+    pub(crate) fn assert_exact(&self, expected: &[TracePattern]) {
         let events = self
             .events
             .lock()
             .expect("trace collector mutex should not be poisoned");
-        let actual_trace = Self::normalized_events(&events);
-        assert_eq!(
-            events.as_slice(),
-            expected,
+        let matches = events.len() == expected.len()
+            && events
+                .iter()
+                .zip(expected)
+                .all(|(event, pattern)| pattern.matches(event));
+
+        assert!(
+            matches,
             "expected exact trace:\n{}actual trace:\n{}",
-            Self::normalized_events(expected),
-            actual_trace
+            Self::normalized_patterns(expected),
+            Self::normalized_events(&events)
         );
     }
 
     #[track_caller]
     pub(crate) fn assert_count(&self, pattern: TracePattern, expected: usize) {
-        let actual = self.count(|event| pattern.matches(event));
+        let actual = self.count(&pattern);
         assert_eq!(
             actual,
             expected,
@@ -243,7 +238,7 @@ impl Trace {
 
     #[track_caller]
     pub(crate) fn assert_absent(&self, pattern: TracePattern) {
-        let actual = self.count(|event| pattern.matches(event));
+        let actual = self.count(&pattern);
         assert_eq!(
             actual,
             0,
@@ -265,6 +260,14 @@ impl Trace {
         let mut output = String::new();
         for (index, event) in events.iter().enumerate() {
             writeln!(output, "{index}: {event}").expect("writing to a String cannot fail");
+        }
+        output
+    }
+
+    fn normalized_patterns(patterns: &[TracePattern]) -> String {
+        let mut output = String::new();
+        for (index, pattern) in patterns.iter().enumerate() {
+            writeln!(output, "{index}: {pattern}").expect("writing to a String cannot fail");
         }
         output
     }
@@ -297,12 +300,13 @@ where
     St: Stream<Item = Result<ProtocolFrame, TransportError>> + Unpin,
 {
     pub(crate) async fn send(&mut self, message: FederateToRti) {
-        let event = TraceEvent::client_to_rti(&message);
+        let frame = ProtocolFrame::FederateToRti(message);
         self.sink
-            .send(ProtocolFrame::FederateToRti(message))
+            .send(frame.clone())
             .await
             .expect("recording client transport should send a protocol frame");
-        self.trace.push(event);
+        self.trace
+            .push(TraceEvent::new(self.federate_id.clone(), frame));
     }
 
     pub(crate) async fn recv(&mut self) -> RtiToFederate {
@@ -312,13 +316,12 @@ where
             .await
             .expect("recording client transport should remain open")
             .expect("recording client transport should receive a protocol frame");
-        let message = match frame {
+        self.trace
+            .push(TraceEvent::new(self.federate_id.clone(), frame.clone()));
+        match frame {
             ProtocolFrame::RtiToFederate(message) => message,
             other => panic!("expected RTI-to-federate frame, got {other:?}"),
-        };
-        self.trace
-            .push(TraceEvent::rti_to_client(&self.federate_id, &message));
-        message
+        }
     }
 }
 
@@ -327,38 +330,64 @@ mod tests {
     use super::*;
     use crate::in_memory_transport_pair;
 
-    fn client(id: &str) -> TraceActor {
-        TraceActor::Client(FederateId::from(id))
+    fn client_to_rti(client_id: &str, message: FederateToRti) -> TraceEvent {
+        TraceEvent::new(
+            FederateId::from(client_id),
+            ProtocolFrame::FederateToRti(message),
+        )
+    }
+
+    fn rti_to_client(client_id: &str, message: RtiToFederate) -> TraceEvent {
+        TraceEvent::new(
+            FederateId::from(client_id),
+            ProtocolFrame::RtiToFederate(message),
+        )
     }
 
     #[test]
-    fn trace_normalizes_frames_to_semantic_fields() {
-        let first = FederateToRti::Msg {
-            source: FederateId::from("source"),
-            target: FederateId::from("target"),
-            endpoint: EndpointId::from("output"),
-            tag: WireTag::finite(10, 2),
-            payload: vec![1, 2, 3],
-        };
-        let second = FederateToRti::Msg {
-            source: FederateId::from("source"),
-            target: FederateId::from("another-target"),
-            endpoint: EndpointId::from("output"),
-            tag: WireTag::finite(10, 2),
-            payload: vec![9],
-        };
-
-        assert_eq!(
-            TraceEvent::client_to_rti(&first),
-            TraceEvent::client_to_rti(&second)
+    fn frame_patterns_ignore_non_semantic_protocol_fields() {
+        let endpoint = EndpointId::from("output");
+        let first = client_to_rti(
+            "source",
+            FederateToRti::Msg {
+                source: FederateId::from("source"),
+                target: FederateId::from("target"),
+                endpoint: endpoint.clone(),
+                tag: WireTag::finite(10, 2),
+                payload: vec![1, 2, 3],
+            },
+        );
+        let second = client_to_rti(
+            "source",
+            FederateToRti::Msg {
+                source: FederateId::from("source"),
+                target: FederateId::from("another-target"),
+                endpoint: endpoint.clone(),
+                tag: WireTag::finite(10, 2),
+                payload: vec![9],
+            },
+        );
+        let pattern = TracePattern::client_to_rti(
+            FederateId::from("source"),
+            FramePattern::Msg {
+                tag: WireTag::finite(10, 2),
+                endpoint,
+            },
         );
 
-        let start = RtiToFederate::Start {
-            start_unix_epoch_ns: 42,
-        };
-        assert_eq!(
-            TraceEvent::rti_to_client(&FederateId::from("target"), &start).message,
-            TraceMessage::Start
+        assert_ne!(first, second);
+        assert!(pattern.matches(&first));
+        assert!(pattern.matches(&second));
+
+        let start = rti_to_client(
+            "target",
+            RtiToFederate::Start {
+                start_unix_epoch_ns: 42,
+            },
+        );
+        assert!(
+            TracePattern::rti_to_client(FederateId::from("target"), FramePattern::Start)
+                .matches(&start)
         );
     }
 
@@ -395,80 +424,51 @@ mod tests {
         );
 
         trace.assert_exact(&[
-            TraceEvent::new(
-                TraceActor::Client(federate_id.clone()),
-                TraceActor::Rti,
-                TraceMessage::Net(WireTag::ZERO),
-            ),
-            TraceEvent::new(
-                TraceActor::Rti,
-                TraceActor::Client(federate_id),
-                TraceMessage::Tag(WireTag::ZERO),
-            ),
+            TracePattern::client_to_rti(federate_id.clone(), FramePattern::Net(WireTag::ZERO)),
+            TracePattern::rti_to_client(federate_id, FramePattern::Tag(WireTag::ZERO)),
         ]);
     }
 
     #[test]
     fn trace_assertions_match_counts_absence_and_causal_order() {
+        let source = FederateId::from("source");
         let trace = Trace::default();
-        trace.push(TraceEvent {
-            from: client("source"),
-            to: TraceActor::Rti,
-            message: TraceMessage::Net(WireTag::ZERO),
-        });
-        trace.push(TraceEvent {
-            from: TraceActor::Rti,
-            to: client("source"),
-            message: TraceMessage::Tag(WireTag::ZERO),
-        });
+        trace.push(client_to_rti(
+            "source",
+            FederateToRti::Net {
+                federate_id: source.clone(),
+                tag: WireTag::ZERO,
+            },
+        ));
+        trace.push(rti_to_client(
+            "source",
+            RtiToFederate::Tag { tag: WireTag::ZERO },
+        ));
 
-        assert_eq!(
-            trace.count(|event| matches!(event.message, TraceMessage::Net(_))),
-            1
-        );
-        assert_eq!(
-            trace.first_position(|event| matches!(event.message, TraceMessage::Tag(_))),
-            Some(1)
-        );
-        trace.assert_count(TracePattern::message(TraceMessage::Net(WireTag::ZERO)), 1);
-        trace.assert_absent(TracePattern::message(TraceMessage::Error));
-        trace.assert_exact(&[
-            TraceEvent::new(
-                client("source"),
-                TraceActor::Rti,
-                TraceMessage::Net(WireTag::ZERO),
-            ),
-            TraceEvent::new(
-                TraceActor::Rti,
-                client("source"),
-                TraceMessage::Tag(WireTag::ZERO),
-            ),
-        ]);
-        trace.assert_before(
-            TracePattern::between(
-                client("source"),
-                TraceActor::Rti,
-                TraceMessage::Net(WireTag::ZERO),
-            ),
-            TracePattern::between(
-                TraceActor::Rti,
-                client("source"),
-                TraceMessage::Tag(WireTag::ZERO),
-            ),
-        );
+        let net = TracePattern::client_to_rti(source.clone(), FramePattern::Net(WireTag::ZERO));
+        let tag = TracePattern::rti_to_client(source, FramePattern::Tag(WireTag::ZERO));
+        assert_eq!(trace.count(&net), 1);
+        assert_eq!(trace.first_position(&tag), Some(1));
+        trace.assert_count(TracePattern::message(FramePattern::Net(WireTag::ZERO)), 1);
+        trace.assert_absent(TracePattern::message(FramePattern::Error));
+        trace.assert_exact(&[net.clone(), tag.clone()]);
+        trace.assert_before(net, tag);
     }
 
     #[test]
     fn trace_assertion_failures_include_the_normalized_sequence() {
+        let source = FederateId::from("source");
         let trace = Trace::default();
-        trace.push(TraceEvent {
-            from: client("source"),
-            to: TraceActor::Rti,
-            message: TraceMessage::Net(WireTag::ZERO),
-        });
+        trace.push(client_to_rti(
+            "source",
+            FederateToRti::Net {
+                federate_id: source,
+                tag: WireTag::ZERO,
+            },
+        ));
 
         let panic = std::panic::catch_unwind(|| {
-            trace.assert_count(TracePattern::message(TraceMessage::Net(WireTag::ZERO)), 2);
+            trace.assert_count(TracePattern::message(FramePattern::Net(WireTag::ZERO)), 2);
         })
         .expect_err("the count assertion should fail");
         let message = panic

--- a/boomerang_federated/src/test_trace.rs
+++ b/boomerang_federated/src/test_trace.rs
@@ -293,6 +293,22 @@ impl Trace {
         );
     }
 
+    /// Asserts the total number of recorded events without imposing a total order.
+    #[track_caller]
+    pub(crate) fn assert_len(&self, expected: usize) {
+        let events = self
+            .events
+            .lock()
+            .expect("trace collector mutex should not be poisoned");
+        assert_eq!(
+            events.len(),
+            expected,
+            "expected {expected} total trace event(s), found {}\ntrace:\n{}",
+            events.len(),
+            Self::normalized_events(&events)
+        );
+    }
+
     fn normalized(&self) -> String {
         Self::normalized_events(
             &self

--- a/boomerang_federated/src/test_trace.rs
+++ b/boomerang_federated/src/test_trace.rs
@@ -85,6 +85,10 @@ pub(crate) struct TraceEvent {
 }
 
 impl TraceEvent {
+    pub(crate) fn new(from: TraceActor, to: TraceActor, message: TraceMessage) -> Self {
+        Self { from, to, message }
+    }
+
     pub(crate) fn client_to_rti(frame: &FederateToRti) -> Self {
         let federate_id = match frame {
             FederateToRti::Hello { federate_id, .. }
@@ -191,6 +195,17 @@ impl Trace {
     }
 
     #[track_caller]
+    pub(crate) fn assert_exact(&self, expected: &[TraceEvent]) {
+        assert_eq!(
+            self.events.as_slice(),
+            expected,
+            "expected exact trace:\n{}actual trace:\n{}",
+            Self::normalized_events(expected),
+            self.normalized()
+        );
+    }
+
+    #[track_caller]
     pub(crate) fn assert_count(&self, pattern: TracePattern, expected: usize) {
         let actual = self.count(|event| pattern.matches(event));
         assert_eq!(
@@ -213,8 +228,12 @@ impl Trace {
     }
 
     fn normalized(&self) -> String {
+        Self::normalized_events(&self.events)
+    }
+
+    fn normalized_events(events: &[TraceEvent]) -> String {
         let mut output = String::new();
-        for (index, event) in self.events.iter().enumerate() {
+        for (index, event) in events.iter().enumerate() {
             writeln!(output, "{index}: {event}").expect("writing to a String cannot fail");
         }
         output
@@ -284,6 +303,18 @@ mod tests {
         );
         trace.assert_count(TracePattern::message(TraceMessage::Net(WireTag::ZERO)), 1);
         trace.assert_absent(TracePattern::message(TraceMessage::Error));
+        trace.assert_exact(&[
+            TraceEvent::new(
+                client("source"),
+                TraceActor::Rti,
+                TraceMessage::Net(WireTag::ZERO),
+            ),
+            TraceEvent::new(
+                TraceActor::Rti,
+                client("source"),
+                TraceMessage::Tag(WireTag::ZERO),
+            ),
+        ]);
         trace.assert_before(
             TracePattern::between(
                 client("source"),

--- a/boomerang_runtime/src/sched/barrier.rs
+++ b/boomerang_runtime/src/sched/barrier.rs
@@ -107,7 +107,8 @@ pub(super) struct LogicalTimeBarrier {
     ///
     /// An unchanged or weaker acquire request reuses this watermark instead of
     /// sending duplicate coordination traffic. A stronger request advances it,
-    /// and an actual release resets it so a later acquire may send a new request.
+    /// and an actual release at or beyond it clears it. An intermediate release
+    /// advances known progress without retiring the stronger outstanding request.
     /// A failed upstream send does not establish the watermark.
     pub(super) provisional_tag: Tag,
     /// The send context for the upstream enclave
@@ -126,10 +127,14 @@ impl LogicalTimeBarrier {
                 "Cannot release a tag ({tag}) earlier than the last released tag {}",
                 self.released_tag
             );
+        } else {
+            self.released_tag = tag;
         }
-        self.released_tag = tag;
-        // Reset the provisional tag
-        self.provisional_tag = Tag::NEVER;
+
+        // Only progress sufficient for the outstanding request retires it.
+        if self.provisional_tag <= self.released_tag {
+            self.provisional_tag = Tag::NEVER;
+        }
     }
 
     pub(super) fn release_tag_provisional(&mut self, tag: Tag) {
@@ -291,6 +296,75 @@ mod tests {
             .unwrap()
             .is_some());
         assert_provisional_request(&upstream_rx, after_release);
+    }
+
+    #[test]
+    fn local_barrier_preserves_pending_request_across_insufficient_release() {
+        let (upstream_tx, upstream_rx) = kanal::unbounded();
+        let (_shutdown_tx, shutdown_rx) = keepalive::channel();
+        let mut barrier = LogicalTimeBarrier {
+            released_tag: Tag::NEVER,
+            provisional_tag: Tag::NEVER,
+            upstream_ctx: SendContext {
+                enclave_key: EnclaveKey::from(1),
+                async_tx: upstream_tx,
+                shutdown_rx,
+            },
+            upstream_delay: None,
+        };
+        let (event_tx, event_rx) = kanal::unbounded();
+        let this_enclave = EnclaveKey::from(0);
+        let intermediate = Tag::new(Duration::seconds(1), 0);
+        let requested = Tag::new(Duration::seconds(2), 0);
+
+        queue_interruption(&event_tx);
+        assert!(barrier
+            .acquire_tag(requested, this_enclave, &event_rx)
+            .unwrap()
+            .is_some());
+        assert_provisional_request(&upstream_rx, requested);
+
+        barrier.release_tag(intermediate);
+        assert_eq!(barrier.released_tag, intermediate);
+        assert_eq!(barrier.provisional_tag, requested);
+
+        queue_interruption(&event_tx);
+        assert!(barrier
+            .acquire_tag(requested, this_enclave, &event_rx)
+            .unwrap()
+            .is_some());
+        assert!(upstream_rx.try_recv().unwrap().is_none());
+
+        barrier.release_tag(requested);
+        assert_eq!(barrier.provisional_tag, Tag::NEVER);
+        assert!(barrier
+            .acquire_tag(requested, this_enclave, &event_rx)
+            .unwrap()
+            .is_none());
+        assert!(upstream_rx.try_recv().unwrap().is_none());
+    }
+
+    #[test]
+    fn local_barrier_release_progress_is_monotonic() {
+        let (upstream_tx, _upstream_rx) = kanal::unbounded();
+        let (_shutdown_tx, shutdown_rx) = keepalive::channel();
+        let released = Tag::new(Duration::seconds(2), 0);
+        let stale = Tag::new(Duration::seconds(1), 0);
+        let mut barrier = LogicalTimeBarrier {
+            released_tag: Tag::NEVER,
+            provisional_tag: Tag::NEVER,
+            upstream_ctx: SendContext {
+                enclave_key: EnclaveKey::from(1),
+                async_tx: upstream_tx,
+                shutdown_rx,
+            },
+            upstream_delay: None,
+        };
+
+        barrier.release_tag(released);
+        barrier.release_tag(stale);
+
+        assert_eq!(barrier.released_tag, released);
     }
 
     #[cfg(feature = "federated")]

--- a/boomerang_runtime/src/sched/barrier.rs
+++ b/boomerang_runtime/src/sched/barrier.rs
@@ -103,6 +103,12 @@ impl std::fmt::Debug for dyn FederatedTimeBarrier {
 pub(super) struct LogicalTimeBarrier {
     /// The last released tag
     pub(super) released_tag: Tag,
+    /// The greatest upstream tag for which a provisional release is outstanding.
+    ///
+    /// An unchanged or weaker acquire request reuses this watermark instead of
+    /// sending duplicate coordination traffic. A stronger request advances it,
+    /// and an actual release resets it so a later acquire may send a new request.
+    /// A failed upstream send does not establish the watermark.
     pub(super) provisional_tag: Tag,
     /// The send context for the upstream enclave
     pub(super) upstream_ctx: SendContext,

--- a/boomerang_runtime/src/sched/barrier.rs
+++ b/boomerang_runtime/src/sched/barrier.rs
@@ -163,20 +163,22 @@ impl LogicalTimeBarrier {
             return Ok(None);
         }
 
-        tracing::trace!(%upstream_tag, "Releasing provisional tag");
-        self.provisional_tag = upstream_tag;
-        if !self
-            .upstream_ctx
-            .release_provisional(this_enclave, upstream_tag)
-        {
-            // The upstream has terminated try to return a queued event here. If the upstream terminated, we probably
-            // have an event queued from it. This prevents pre-mature termination of this enclave.
-            tracing::warn!("Upstream has terminated");
-            return event_rx
-                .try_recv()
-                .map_err(|_| LogicalTimeBarrierError::EventChannelClosed {
-                    upstream: self.upstream_ctx.enclave_id(),
+        if upstream_tag > self.provisional_tag {
+            tracing::trace!(%upstream_tag, "Releasing provisional tag");
+            if !self
+                .upstream_ctx
+                .release_provisional(this_enclave, upstream_tag)
+            {
+                // The upstream has terminated try to return a queued event here. If the upstream terminated, we probably
+                // have an event queued from it. This prevents pre-mature termination of this enclave.
+                tracing::warn!("Upstream has terminated");
+                return event_rx.try_recv().map_err(|_| {
+                    LogicalTimeBarrierError::EventChannelClosed {
+                        upstream: self.upstream_ctx.enclave_id(),
+                    }
                 });
+            }
+            self.provisional_tag = upstream_tag;
         }
 
         // Block until the tag is released
@@ -194,6 +196,18 @@ impl LogicalTimeBarrier {
 mod tests {
     use super::*;
     use crate::keepalive;
+
+    fn queue_interruption(event_tx: &crate::Sender<AsyncEvent>) {
+        event_tx.send(AsyncEvent::shutdown(Duration::ZERO)).unwrap();
+    }
+
+    fn assert_provisional_request(upstream_rx: &crate::Receiver<AsyncEvent>, expected_tag: Tag) {
+        assert!(matches!(
+            upstream_rx.try_recv().unwrap(),
+            Some(AsyncEvent::TagReleaseProvisional { enclave, tag })
+                if enclave == EnclaveKey::from(0) && tag == expected_tag
+        ));
+    }
 
     #[test]
     fn local_barrier_reports_closed_scheduler_event_channel_without_panicking() {
@@ -219,6 +233,58 @@ mod tests {
             Err(LogicalTimeBarrierError::EventChannelClosed { upstream: observed })
                 if observed == upstream
         ));
+    }
+
+    #[test]
+    fn local_barrier_suppresses_repeated_provisional_requests_until_release() {
+        let (upstream_tx, upstream_rx) = kanal::unbounded();
+        let (_shutdown_tx, shutdown_rx) = keepalive::channel();
+        let mut barrier = LogicalTimeBarrier {
+            released_tag: Tag::NEVER,
+            provisional_tag: Tag::NEVER,
+            upstream_ctx: SendContext {
+                enclave_key: EnclaveKey::from(1),
+                async_tx: upstream_tx,
+                shutdown_rx,
+            },
+            upstream_delay: None,
+        };
+        let (event_tx, event_rx) = kanal::unbounded();
+        let this_enclave = EnclaveKey::from(0);
+        let first = Tag::new(Duration::seconds(1), 0);
+        let later = Tag::new(Duration::seconds(2), 0);
+        let after_release = Tag::new(Duration::seconds(3), 0);
+
+        queue_interruption(&event_tx);
+        assert!(barrier
+            .acquire_tag(first, this_enclave, &event_rx)
+            .unwrap()
+            .is_some());
+        assert_provisional_request(&upstream_rx, first);
+
+        for repeated_or_weaker in [first, Tag::ZERO] {
+            queue_interruption(&event_tx);
+            assert!(barrier
+                .acquire_tag(repeated_or_weaker, this_enclave, &event_rx)
+                .unwrap()
+                .is_some());
+            assert!(upstream_rx.try_recv().unwrap().is_none());
+        }
+
+        queue_interruption(&event_tx);
+        assert!(barrier
+            .acquire_tag(later, this_enclave, &event_rx)
+            .unwrap()
+            .is_some());
+        assert_provisional_request(&upstream_rx, later);
+
+        barrier.release_tag(later);
+        queue_interruption(&event_tx);
+        assert!(barrier
+            .acquire_tag(after_release, this_enclave, &event_rx)
+            .unwrap()
+            .is_some());
+        assert_provisional_request(&upstream_rx, after_release);
     }
 
     #[cfg(feature = "federated")]

--- a/docs/federated-protocol.md
+++ b/docs/federated-protocol.md
@@ -196,10 +196,21 @@ federation shutdown. An error is never interpreted as a tag grant.
 
 ## Performance Considerations
 
-The current `MsgAck` contract sends one control frame per delivered message.
-This is deliberately exact and keeps same-tag accounting correct, but it can be
-expensive for high-rate small-message traffic: each `MSG` adds another client
-write, serialization step, RTI dispatch, and grant retry.
+The client keeps at most one outstanding `NET` for an unchanged next-event
+request. Once that frame has been queued successfully, an unrelated inbound
+message may interrupt the scheduler wait without causing the same `NET` to be
+sent again. A distinct later request sends one new `NET`; a sufficient `TAG`,
+normal stop, or a terminal protocol, transport, RTI, or runtime error clears the
+outstanding request. This is an efficiency contract, not permission to suppress
+`NET` frames whose requested tag has changed.
+
+The current `MsgAck` contract sends exactly one control frame per successfully
+decoded and queued delivered message. This is deliberately exact and keeps
+same-tag accounting correct, but it can be expensive for high-rate
+small-message traffic: each `MSG` adds another client write, serialization
+step, RTI dispatch, and grant retry. Failed queue delivery is not acknowledged,
+and neither `LTC` nor another same-tag acknowledgment substitutes for the
+required one-to-one acknowledgment.
 
 A future protocol may batch acknowledgments by target and tag, acknowledge
 sequence ranges, or piggyback counts on another control frame. Any such change
@@ -209,6 +220,16 @@ must preserve these properties:
 - each message decrements the RTI count exactly once;
 - one acknowledgment cannot accidentally clear other same-tag messages; and
 - pending grants are reconsidered promptly enough to avoid artificial stalls.
+
+Protocol trace tests distinguish causal requirements from incidental
+implementation ordering. They assert exact counts, absence, bounded control
+traffic, and relations such as forwarded `MSG` before matching `MsgAck` and
+matching `MsgAck` before a grant that it unblocks. They assert a complete total
+order only in the hand-driven reference session where the harness deliberately
+chooses every exchange. Concurrently independent `NET`, `TAG`, and `LTC`
+interleavings are not protocol contracts. The positive-delay-cycle reference
+therefore uses a derived budget of one `NET`, one `TAG`, and one `LTC` per
+federate and requested watermark rather than relying on thread timing.
 
 The live command channels are also currently unbounded. Introducing bounded
 backpressure requires care because blocking a scheduler reaction before its


### PR DESCRIPTION
## Summary

- add a typed, test-only protocol trace that records raw protocol frames at the transport boundary and projects them into compact semantic assertions
- cover a deterministic source-to-sink exchange, exact same-tag message acknowledgment cardinality, interrupted retry behavior, and bounded progress through a positive-delay cycle
- eliminate duplicate federated next-event and local provisional-release requests while preserving all protocol-required acknowledgments, completion, startup, and shutdown traffic
- document the resulting coordination contracts and their optimization boundaries

## Protocol bugs found and fixed

The trace-first tests exposed two related retry bugs.

First, an inbound federated message could interrupt a scheduler waiting for a tag grant. When the scheduler retried the unchanged acquire, the client had forgotten that its previous next-event request was still outstanding and sent a duplicate NET for the same tag. This generated redundant RTI dispatch and grant-retry work. The client now keeps an outstanding-request watermark after a NET is successfully queued, preserves it across unrelated inbound traffic, clears it on a sufficient TAG or terminal condition, and still emits one new NET for a distinct later request.

Second, the local logical-time barrier recorded a provisional tag but did not use it to suppress retries. An unrelated asynchronous interruption followed by the same acquire therefore sent another identical provisional-release request upstream. The existing provisional tag is now the outstanding watermark: unchanged or weaker requests reuse it, a stronger request advances it once, a sufficient actual release resets it, and a failed upstream send does not establish it.

Follow-up review exposed a second local edge case in that fix: every actual release cleared the outstanding watermark, even when the released tag was earlier than the stronger request still queued upstream. That intermediate progress reopened the same provisional request, and a stale release could also move the barrier's known progress backward. Local release progress is now monotonic, and only progress at or beyond the outstanding request retires it. New tests reproduce both failures before the fix and cover insufficient, sufficient, and stale releases.

The trace work also makes an important non-bug explicit: MsgAck is deliberately one-for-one. Every successfully queued delivered message requires exactly one acknowledgment, including multiple messages at the same tag. The optimization does not batch or remove MsgAck, LTC, payload, handshake, no-future, or stop frames.

## Trace contracts

The test-only recording transport retains raw typed ProtocolFrame values losslessly. FramePattern supplies a deliberately smaller semantic view for count, absence, causal-order, and exact-sequence assertions.

Exact total order is used only for the explicitly hand-driven 18-event reference flow. Concurrent scenarios assert causal relations and budgets instead of incidental scheduling order. The positive-delay two-federate cycle grants both federates at 0 ns, 10 ns, and 20 ns with exactly six NET, six TAG, and six LTC events, and reaches quiescence through ordered stop delivery.

## Validation

- cargo fmt --all -- --check
- cargo clippy -p boomerang_runtime -p boomerang_federated --all-targets --all-features -- -D warnings
- cargo test -p boomerang_runtime
- cargo test -p boomerang_runtime --features federated
- cargo test -p boomerang_federated
- cargo test -p boomerang_federated --features runtime
- cargo test -p boomerang_builder --features federated
- cargo test -p boomerang --features federated
- cargo test
- git diff --check

Closes #92.

Part of #91.
