### PR TITLE
ci: reduce Actions and Renovate workload

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -5,11 +5,19 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
-      contents: write # To push a branch
+      contents: read
       pages: write # To push to a GitHub Pages site
       id-token: write # To update the deployment status
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,4 +88,4 @@ jobs:
       - name: Test with Miri
         env:
           MIRIFLAGS: -Zmiri-disable-isolation
-        run: cargo +nightly miri nextest run
+        run: cargo +nightly miri nextest run -p boomerang -E 'kind(test)'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,9 @@ jobs:
         with:
           toolchain: nightly
           components: miri
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@nextest
       - name: Test with Miri
-        run: |
-          export MIRIFLAGS="-Zmiri-disable-isolation"
-          cargo +nightly miri setup && cargo +nightly miri test
+        env:
+          MIRIFLAGS: -Zmiri-disable-isolation
+        run: cargo +nightly miri nextest run

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,16 +7,39 @@ on:
   pull_request:
     branches: ["main"]
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
   commitlint:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     name: Commitlint
     steps:
       - name: Run commitlint
         uses: opensource-nepal/commitlint@v1
+
+  clippy:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    name: Clippy
+    steps:
+      - uses: actions/checkout@v7
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - uses: swatinem/rust-cache@v2
+      - name: Check with Clippy
+        run: cargo clippy --workspace --all-targets --all-features -- -D warnings
 
   test:
     strategy:
@@ -32,6 +55,7 @@ jobs:
             toolchain: nightly
 
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
 
     steps:
       - uses: actions/checkout@v7
@@ -44,44 +68,12 @@ jobs:
       - name: toolchain version
         run: cargo -vV
 
-      - name: Clippy
-        if: github.event_name == 'pull_request'
-        uses: giraffate/clippy-action@v1
-        with:
-          reporter: "github-pr-review"
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          clippy_flags: -- -Dwarnings
-
-      - name: build
-        run: cargo build --all --verbose
-
       - name: test
         run: cargo test --all --verbose
 
-  #check-unused-dependencies:
-  #  runs-on: ubuntu-latest
-  #  steps:
-  #    - uses: actions/checkout@v3
-  #    - uses: actions/cache@v3
-  #      with:
-  #        path: |
-  #          ~/.cargo/bin/
-  #          ~/.cargo/registry/index/
-  #          ~/.cargo/registry/cache/
-  #          ~/.cargo/git/db/
-  #          target/
-  #        key: ${{ runner.os }}-cargo-check-unused-dependencies-${{ hashFiles('**/Cargo.toml') }}
-  #    - uses: actions-rs/toolchain@v1
-  #      with:
-  #        toolchain: nightly
-  #        override: true
-  #    - name: Installs cargo-udeps
-  #      run: cargo install --force cargo-udeps
-  #    - name: Run cargo udeps
-  #      run: cargo udeps
-
   miri:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -1,10 +1,22 @@
 name: Code Coverage
 
-on: [pull_request, push]
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   coverage:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     env:
       CARGO_TERM_COLOR: always
@@ -13,7 +25,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Install Rust
-        run: rustup update stable
+        uses: dtolnay/rust-toolchain@stable
 
       - uses: swatinem/rust-cache@v2
 

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -38,6 +39,6 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v7
         with:
-          token: ${{ secrets.CODECOV_TOKEN }} # not required for public repos
           files: lcov.info
           fail_ci_if_error: true
+          use_oidc: true

--- a/boomerang/benches/ping_pong.rs
+++ b/boomerang/benches/ping_pong.rs
@@ -121,7 +121,6 @@ fn bench(c: &mut Criterion) {
                     let config = runtime::Config::default().with_fast_forward(true);
                     let BuilderRuntimeParts {
                         enclaves,
-                        aliases: _,
                         ..
                     } = env_builder.into_runtime_parts(&config).unwrap();
                     let (enclave_key, enclave) = enclaves.into_iter().next().unwrap();

--- a/boomerang_builder/src/tests.rs
+++ b/boomerang_builder/src/tests.rs
@@ -1281,7 +1281,6 @@ fn test_enclave2() {
 
     let BuilderRuntimeParts {
         enclaves,
-        aliases: _,
         ..
     } = env_builder
         .into_runtime_parts(&runtime::Config::default())

--- a/boomerang_runtime/src/port/mod.rs
+++ b/boomerang_runtime/src/port/mod.rs
@@ -59,7 +59,7 @@ impl<T: ReactorData> Display for Port<T> {
             f,
             "Port<{ty}>(\"{name}\", {key})",
             ty = std::any::type_name::<T>(),
-            name = &self.name,
+            name = self.name,
             key = self.key
         )
     }

--- a/boomerang_util/src/runner.rs
+++ b/boomerang_util/src/runner.rs
@@ -103,7 +103,6 @@ pub fn build_and_test_reactor<S: runtime::ReactorData, R: Reactor<S>>(
 
     let BuilderRuntimeParts {
         enclaves,
-        aliases: _,
         ..
     } = env_builder
         .into_runtime_parts(&config)
@@ -175,7 +174,6 @@ where
 
     let BuilderRuntimeParts {
         enclaves,
-        aliases: _,
         #[cfg(feature = "replay")]
         replayers,
         ..

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,3 @@
-codecov:
-  token: 9ca1bec2-fd82-413b-90f1-bc2b709e2954
-
 coverage:
   status:
     project:

--- a/examples/snake/src/keyboard.rs
+++ b/examples/snake/src/keyboard.rs
@@ -65,7 +65,6 @@ fn main() {
         .with_keep_alive(true);
     let BuilderRuntimeParts {
         enclaves,
-        aliases: _,
         ..
     } = env_builder.into_runtime_parts(&config).unwrap();
 

--- a/renovate.json
+++ b/renovate.json
@@ -2,29 +2,16 @@
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
     "extends": [
         "config:recommended",
+        "group:all",
         ":automergeAll",
-        ":automergeBranch",
         ":automergeRequireAllStatusChecks",
-        ":semanticCommits",
-        "schedule:weekly",
-        "schedule:automergeWeekly"
+        ":semanticCommits"
     ],
-    "packageRules": [
-        {
-            "groupName": "rust dependencies",
-            "groupSlug": "rust",
-            "matchDatasources": [
-                "crate"
-            ]
-        },
-        {
-            "groupName": "github ci dependencies",
-            "groupSlug": "ci",
-            "matchDatasources": [
-                "github-tags",
-                "gitea-tags",
-                "github-runners"
-            ]
-        }
-    ]
+    "timezone": "Europe/Berlin",
+    "schedule": [
+        "* 0-3 1,15 * *"
+    ],
+    "branchConcurrentLimit": 1,
+    "prConcurrentLimit": 1,
+    "prHourlyLimit": 1
 }


### PR DESCRIPTION
## Summary

- run coverage once per PR and once after changes land on main
- cancel superseded CI and coverage runs
- run Clippy once per PR instead of once per test-matrix entry
- remove the redundant build that immediately preceded cargo test
- run only the `boomerang` integration tests under Miri, parallelized across the public runner's four CPUs with Nextest
- add least-privilege token permissions and job timeouts
- reduce Pages permissions from contents: write to contents: read
- remove the plaintext Codecov token from repository configuration
- group all Renovate updates into one PR, limited to the 1st and 15th of each month (00:00-04:00 Europe/Berlin), with one concurrent branch/PR

## Validation

- all workflow and Codecov YAML parses successfully
- git diff --check passes
- cargo metadata succeeds
- cargo +stable clippy --workspace --all-targets --all-features -- -D warnings passes
- Renovate official config validator passes in strict mode
- all PR checks pass, including Codecov upload through GitHub OIDC
- scoped Miri completes in 7m47s, about 30% faster than the previous 11m07s run

## Miri trade-off

Nextest runs each integration test in a separate Miri process, allowing GitHub runner cores to work in parallel. The filter `package(boomerang) & kind(test)` excludes workspace unit tests, benches, and examples while retaining the integration tests that exercise the scheduler. This preserves per-test undefined-behavior checks but does not detect races between separate tests sharing an external resource.

## Follow-up

The Codecov token was committed publicly and remains in Git history. It should be rotated in Codecov even though this change removes it from the current configuration.
